### PR TITLE
Update language_config.json

### DIFF
--- a/webapp/data/languages/gd/language_config.json
+++ b/webapp/data/languages/gd/language_config.json
@@ -5,7 +5,7 @@
     "meta": {
         "locale": "gd",
         "title": "An geama fhaclan làitheil",
-        "description": "Tomhais am facal falaichte ann an 6 oidhirpean (no nas lugha). Bidh tòimhseachan ùr ri fhaighinn gach latha!",
+        "description": "Tomhais am facal falaichte ann an sia oidhirpean (no nas lugha). Bidh tòimhseachan ùr ri fhaighinn gach latha!",
         "keywords": "Gàidhlig, tòimhseachan, facal, cluich, geama, air loidhne, tomhais, a' tomhas, gach latha, facle"
     },
     "text": {
@@ -14,7 +14,7 @@
         "no_attempts": "Chan eil thu air facal sam bith fheuchainn fhathast!",
         "share": "Co-roinn ",
         "notification-copied": "Chaidh a chur air an stòr-bhòrd",
-        "notification-partial-word": "Cuir a-steach facal slàn "
+        "notification-partial-word": "Cuir a-steach facal slàn"
     },
     "language_code_3": "",
     "language_code_iso_639_3": "",
@@ -28,7 +28,7 @@
         "text_1_2": "Feumaidh gach oidhirp a bhith na fhacal slàn a tha còig litir a dh’fhaid. Brùth air a' phutan ENTER feuch a bheil thu ceart.",
         "text_1_3": "Às deidh dhut tomhas a dhèanamh, thig atharrachadh air dathan nan leacagan is innsidh seo dhut dè na litrichean dhen fhacal a tha ceart no cha mhòr ceart.",
         "text_2_1": ": anns an fhacal agus san àite cheart!",
-        "text_2_2": ": anns an fhacal ach chan san àite cheart.",
+        "text_2_2": ": anns an fhacal ach chan ann san àite cheart.",
         "text_2_3": ": chan eil seo san fhacal a tha ri thomhas.",
         "text_3": "Bidh facal ùr ri thomhas gach latha!"
     }


### PR DESCRIPTION
a few non-critical tweaks, (missed a word), removed a space at the end of a line and changed 6 to 'sia'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Gaelic text strings for improved phrasing and grammatical accuracy in user notifications and instructions.
  - Replaced numeric "6" with the Gaelic word "sia" for consistency.
  - Removed an unnecessary trailing space in a notification message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->