### PR TITLE
SEO: keyword-rich meta descriptions for all 65 languages

### DIFF
--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -8,7 +8,24 @@
 
     {# Page-specific SEO meta tags #}
     {% set title = "Play Wordle in " ~ language.config.name ~ " — Free Daily Word Game (" ~ language.config.name_native ~ ")" %}
-    {% set description = language.config.meta.description %}
+    {% set seo_tail = "Free unlimited word puzzle in 65+ languages." %}
+    {% if language.config.name|lower == language.config.name_native|lower %}
+        {% set seo_prefix = "Play Wordle in " ~ language.config.name ~ " — " %}
+    {% else %}
+        {% set seo_prefix = "Play Wordle in " ~ language.config.name ~ " (" ~ language.config.name_native ~ ") — " %}
+    {% endif %}
+    {% set native_desc = language.config.meta.description %}
+    {% set full_desc = seo_prefix ~ native_desc ~ " " ~ seo_tail %}
+    {% if full_desc|length > 160 %}
+        {# Use first sentence only to keep under 160 chars #}
+        {% set first_sentence = native_desc.split('. ')[0] %}
+        {% if not first_sentence.endswith(('.', '!', '?', ':', '։')) %}
+            {% set first_sentence = first_sentence ~ "." %}
+        {% endif %}
+        {% set description = seo_prefix ~ first_sentence ~ " " ~ seo_tail %}
+    {% else %}
+        {% set description = full_desc %}
+    {% endif %}
     <title>{{ title }}</title>
     <meta name="description" content="{{ description }}">
     <meta property="description" content="{{ description }}">
@@ -68,7 +85,6 @@
                         <h1 class="uppercase font-bold text-2xl sm:text-4xl tracking-wider"><a href="/">Wordle <span
                                     class="text-xl sm:text-xl bg-gradient-to-r from-cyan-500 to-blue-500 text-white rounded px-1 py-0">
                                     {{ language.config.language_code }}</span></a></h1>
-                        </h1>
                     </div>
                     <div class="flex flex-row gap-3 z-30">
                         <button class="m-0 sm:my-1" v-on:click="show_stats_modal = !show_stats_modal">
@@ -574,7 +590,7 @@
         <button class="dismiss" onclick="dismissPwaInstall()">&times;</button>
     </div>
 
-    {% set description = "Play Wordle in " ~ language.config.name_native %}
+    {% set pwa_description = "Play Wordle in " ~ language.config.name_native %}
     {% include 'partials/_pwa_install.html' %}
 
     <!-- Vite-built JS (includes Vue, game logic, PWA) -->

--- a/webapp/templates/partials/_pwa_install.html
+++ b/webapp/templates/partials/_pwa_install.html
@@ -6,6 +6,6 @@
 <pwa-install
     manifest-url="{{ url_for('static', filename='manifest.json') }}"
     name="Wordle Global"
-    description="{{ description|default('Play Wordle in 65+ languages') }}"
+    description="{{ pwa_description|default('Play Wordle in 65+ languages') }}"
     install-description="Install for quick daily access"
 ></pwa-install>


### PR DESCRIPTION
## Summary

- Build SEO-optimized meta descriptions in the template for all 65 language game pages
- Pattern: `Play Wordle in {English} ({Native}) — {native description} Free unlimited word puzzle in 65+ languages.`
- Adaptively uses full native description when under 160 chars, first sentence only when over
- Each language gets a unique description (no more duplicates)

## Bing Webmaster Tools issues fixed

| Issue | Severity | Pages | Status |
|-------|----------|-------|--------|
| Meta descriptions too short | Moderate | 61 | Fixed (now 124-160 chars) |
| Identical meta descriptions | Moderate | 21 | Fixed (each unique) |
| Missing `<h1>` tag | High | 4 | Likely stale scan — `<h1>` exists in template |
| Missing description | High | 4 | Likely stale scan — description exists |

## SEO keywords targeted (from Google Search Console top queries)

- "wordle" + language name (English): "wordle deutsch" (93K imp), "wordle english" (74K)
- "wordle" + language name (native): "wordle türkçe" (29.7K), "wordle español" (27.4K)
- Modifiers: "free", "unlimited", "word puzzle"

## Also fixes

- Duplicate `</h1>` closing tag on game page
- PWA `description` variable no longer overwrites SEO `description`

## Examples

| Language | Chars | Description |
|----------|-------|-------------|
| English | 149 | Play Wordle in English — Guess the hidden word in 6 tries (or less). A new puzzle is available each day! Free unlimited word puzzle in 65+ languages. |
| Finnish | 152 | Play Wordle in Finnish (Suomi) — Arvaa sana maksimissaan 6 yrityksellä. Uusi sana on saatavilla joka päivä! Free unlimited word puzzle in 65+ languages. |
| German | 141 | Play Wordle in German (Deutsch) — Erraten Sie das verborgene Wort in 6 Versuchen (oder weniger). Free unlimited word puzzle in 65+ languages. |
| Arabic | 145 | Play Wordle in Arabic (العربية) — تخمين الكلمة المخفية في 6 محاولات (أو أقل). لغز جديد متاح كل يوم! Free unlimited word puzzle in 65+ languages. |

## Test plan

- [x] All 65 languages render unique meta descriptions
- [x] meta, og:description, and twitter:description all match
- [x] No description exceeds 160 chars
- [x] `pytest tests/` passes (2003 passed)
- [ ] Verify in browser dev tools for a few language pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a template syntax error in the game page.

* **Improvements**
  * Enhanced SEO description generation with character limit enforcement and proper formatting.
  * Updated PWA installation description variable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->