### PR TITLE
fix: definition coverage gaps in words hub and 5 small languages

### DIFF
--- a/webapp/wiktionary.py
+++ b/webapp/wiktionary.py
@@ -741,6 +741,11 @@ LLM_LANG_NAMES = {
     "mt": "Maltese",
     "hyw": "Western Armenian",
     "ckb": "Central Kurdish",
+    "pau": "Palauan",
+    "ie": "Interlingue",
+    "rw": "Kinyarwanda",
+    "tlh": "Klingon",
+    "qya": "Quenya",
 }
 
 


### PR DESCRIPTION
## Summary

- **Words hub + word pages** (`/<lang>/words`, `/<lang>/word/<id>`) only read definitions from the disk cache, completely missing the 206K pre-built kaikki definitions that are already loaded in memory. This caused most words on the words hub to show no definition — e.g. Spanish showed definitions for only 3 out of 7,405 words.
- **5 small/constructed languages** (Palauan, Interlingue, Kinyarwanda, Klingon, Quenya) had zero definition coverage — they fall through all 4 tiers (no kaikki files, UNRELIABLE parser confidence, not in LLM allowlist).

## Changes

1. **`app.py`**: Both `language_words_hub()` and `word_page()` now fall back to `lookup_kaikki_native()` → `lookup_kaikki_english()` on disk cache miss. These are in-memory dict lookups (zero latency, no network calls).
2. **`wiktionary.py`**: Added `pau`, `ie`, `rw`, `tlh`, `qya` to `LLM_LANG_NAMES` so they can use the gpt-4o-mini fallback.

## Test plan

- [x] All 2,250 tests pass, 198 parser tests pass
- [ ] Visit `/es/words` — definitions should now appear for all words with kaikki entries
- [ ] Visit `/pau/words` — LLM definitions should be fetchable via individual word pages
- [ ] Visit `/en/word/<id>` — definition should server-render without needing JS fallback fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced definition retrieval across word hub and word pages with automatic fallback when cached definitions are unavailable.
  * Added support for 5 new languages: Palauan, Interlingue, Kinyarwanda, Klingon, and Quenya.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->