### PR TITLE
fix: Android PWA keyboard bottom row clipping

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -71,6 +71,14 @@
     padding-bottom: env(safe-area-inset-bottom);
 }
 
+/* Android PWA: gesture bar overlaps app but env(safe-area-inset-bottom) is 0,
+   so add fallback bottom padding in standalone mode to prevent keyboard clipping */
+@media (display-mode: standalone) {
+    .safe-area-inset {
+        padding-bottom: max(env(safe-area-inset-bottom), 12px);
+    }
+}
+
 /* PWA Install Banner */
 .pwa-install-banner {
     position: fixed;

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -17,6 +17,14 @@ button, .key, input, a {
     padding-bottom: env(safe-area-inset-bottom);
 }
 
+/* Android PWA: gesture bar overlaps app but env(safe-area-inset-bottom) is 0,
+   so add fallback bottom padding in standalone mode to prevent keyboard clipping */
+@media (display-mode: standalone) {
+    .safe-area-inset {
+        padding-bottom: max(env(safe-area-inset-bottom), 12px);
+    }
+}
+
 /* Keyboard key styles */
 .key {
     background-color: #d3d6da;


### PR DESCRIPTION
## Summary
- On Android PWAs, the system gesture bar overlaps app content but `env(safe-area-inset-bottom)` reports `0` (unlike iOS which correctly reports safe area insets)
- This causes the bottom keyboard row to be hidden behind the gesture bar in standalone/PWA mode
- Adds a `@media (display-mode: standalone)` rule with `padding-bottom: max(env(safe-area-inset-bottom), 12px)` as a fallback
- On iOS where the inset is already correct (e.g. 34px), `max()` picks the larger value so nothing changes
- Only affects PWA standalone mode — regular browser experience is unchanged

## Context
We've gone back and forth between `100svh` and `100dvh` in recent PRs (#138, commits 0155c09, 6eb3a7d). Neither viewport unit solves this because they account for browser chrome, not the Android system navigation/gesture bar. This fix targets the actual root cause.

## Test plan
- [ ] Test on Android PWA (Brave) — bottom keyboard row should be fully visible
- [ ] Test on Android PWA (Chrome) — same
- [ ] Test on iOS PWA — no regression (safe-area-inset-bottom should still win via max())
- [ ] Test in regular mobile browser — no change (standalone media query doesn't apply)

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard clipping issue when using PWA applications in standalone mode on Android devices by implementing improved viewport padding handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->