### PR TITLE
fix: prevent PWA install dialog from auto-showing on page load

### DIFF
--- a/webapp/templates/partials/_pwa_install.html
+++ b/webapp/templates/partials/_pwa_install.html
@@ -8,4 +8,6 @@
     name="Wordle Global"
     description="{{ pwa_description|default('Play Wordle in 65+ languages') }}"
     install-description="Install for quick daily access"
+    manual-apple
+    manual-chrome
 ></pwa-install>


### PR DESCRIPTION
## Summary
- The `@khmyznikov/pwa-install` web component has built-in auto-display behavior that shows an install dialog on page load — independent of our custom banner
- On iOS: triggers via `_triggerAppleDialog()` 500ms after load
- On Android: triggers when `beforeinstallprompt` fires
- This is distracting when the user is mid-game and hasn't finished yet
- Adds `manual-apple` and `manual-chrome` attributes to suppress auto-display
- Our custom banner (shown 2s after game win) still calls `showDialog()` explicitly, so the install flow is unchanged

## Test plan
- [ ] Open game on iOS Safari — install dialog should NOT auto-appear on load
- [ ] Open game on Android Chrome — install dialog should NOT auto-appear on load
- [ ] Win a game — custom banner should appear after 2s, tapping "Install" should open the pwa-install dialog
- [ ] Verify PWA install still works end-to-end on both platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PWA install component now supports configurable manual installation instructions for Apple and Chrome platforms, providing enhanced control over platform-specific installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->