### PR TITLE
feat: polished animations — tile flip, win bounce, shake, modal transitions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.14
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
@@ -100,7 +106,9 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: |
+          uv sync
+          pnpm install
 
       - name: Type check
         run: pnpm exec vue-tsc --noEmit

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -28,6 +28,8 @@ import type {
     KeyState,
 } from './types';
 
+const WIN_WORDS = ['Genius', 'Magnificent', 'Impressive', 'Splendid', 'Great', 'Phew'] as const;
+
 // Total stats across all languages
 interface TotalStats {
     total_games: number;
@@ -118,6 +120,9 @@ interface GameData {
     total_stats: TotalStats;
     languages: Record<string, LanguageInfo>;
     shareButtonState: 'idle' | 'success';
+    animating: boolean;
+    shaking_row: number;
+    pendingKeyUpdates: Array<{ char: string; state: KeyState } | undefined>;
     communityPercentile: number | null;
     communityIsTopScore: boolean;
     communityTotal: number;
@@ -154,12 +159,18 @@ export const createGameApp = () => {
                 feedbackEnabled: true,
                 wordInfoEnabled: true,
                 shareButtonState: 'idle' as const,
+                animating: false,
+                shaking_row: -1,
+                pendingKeyUpdates: [] as Array<{ char: string; state: KeyState } | undefined>,
 
                 notification: {
                     show: false,
+                    fading: false,
                     message: '',
                     top: 0,
                     timeout: 0,
+                    fadeTimeout: 0,
+                    slideInterval: 0,
                 },
 
                 tiles: [
@@ -510,7 +521,8 @@ export const createGameApp = () => {
                 const classes = this.tile_classes[this.active_row];
                 if (!row || !classes) return;
 
-                const keyClasses = this.key_classes as Record<string, KeyState>;
+                // Store per-tile keyboard updates for staggered reveal
+                this.pendingKeyUpdates = [];
 
                 // First pass: mark correct positions (using normalized comparison)
                 for (let i = 0; i < row.length; i++) {
@@ -521,7 +533,10 @@ export const createGameApp = () => {
                         classes.splice(i, 1, `correct ${baseClass}`);
                         // Update tile to show target's character (e.g., user typed "ä" but target has "a")
                         row.splice(i, 1, targetChar);
-                        this.updateKeyColor(guessChar, 'key-correct', keyClasses);
+                        this.pendingKeyUpdates[i] = {
+                            char: guessChar,
+                            state: 'key-correct' as KeyState,
+                        };
                         const normalizedChar = fullNormalize(guessChar);
                         const count = charCounts[normalizedChar];
                         if (count !== undefined) charCounts[normalizedChar] = count - 1;
@@ -544,12 +559,18 @@ export const createGameApp = () => {
                     if (targetHasChar && count !== undefined && count > 0) {
                         // Use splice for Vue 3 reactivity
                         classes.splice(i, 1, `semicorrect ${baseClass}`);
-                        this.updateKeyColor(guessChar, 'key-semicorrect', keyClasses);
+                        this.pendingKeyUpdates[i] = {
+                            char: guessChar,
+                            state: 'key-semicorrect' as KeyState,
+                        };
                         charCounts[normalizedGuess] = count - 1;
                     } else {
                         // Use splice for Vue 3 reactivity
                         classes.splice(i, 1, `incorrect ${baseClass}`);
-                        this.updateKeyColor(guessChar, 'key-incorrect', keyClasses);
+                        this.pendingKeyUpdates[i] = {
+                            char: guessChar,
+                            state: 'key-incorrect' as KeyState,
+                        };
                     }
                 }
             },
@@ -566,8 +587,21 @@ export const createGameApp = () => {
                 const updateSingleKey = (key: string, state: KeyState) => {
                     const current = keyClasses[key];
                     // Priority: key-correct > key-semicorrect > key-incorrect
-                    if (current === 'key-correct') return;
-                    if (current === 'key-semicorrect' && state === 'key-incorrect') return;
+                    if (current === 'key-correct') {
+                        // Already green — pulse to acknowledge
+                        if (state === 'key-correct') this._nudgeKey(key, 'key-pulse');
+                        return;
+                    }
+                    if (current === 'key-semicorrect' && state === 'key-incorrect') {
+                        // Already yellow, new info says grey — shake (wasted guess)
+                        this._nudgeKey(key, 'key-shake');
+                        return;
+                    }
+                    if (current === 'key-incorrect' && state === 'key-incorrect') {
+                        // Already grey — shake (wasted guess)
+                        this._nudgeKey(key, 'key-shake');
+                        return;
+                    }
                     keyClasses[key] = state;
                 };
 
@@ -596,6 +630,7 @@ export const createGameApp = () => {
             },
 
             keyDown(event: KeyboardEvent | { key: string }): void {
+                if (this.animating) return;
                 const key = event.key;
 
                 if (key === 'Escape') {
@@ -609,6 +644,7 @@ export const createGameApp = () => {
 
                 if (['Enter', '⇨', '⟹', 'ENTER'].includes(key)) {
                     if (!this.full_word_inputted) {
+                        this.shakeRow(this.active_row);
                         this.showNotification('Please enter a full word');
                         return;
                     }
@@ -639,20 +675,30 @@ export const createGameApp = () => {
                         }
 
                         this.updateColors();
+                        const revealingRow = this.active_row;
                         this.active_row++;
                         this.active_cell = 0;
                         this.full_word_inputted = false;
+                        this.animating = true;
 
-                        // Compare normalized forms for win detection
-                        const normalizedGuess = normalizeWord(canonicalWord, normalizeMap);
-                        const normalizedTarget = normalizeWord(this.todays_word, normalizeMap);
-                        if (normalizedGuess === normalizedTarget) {
-                            this.gameWon();
-                        } else if (this.active_row === 6) {
-                            this.gameLost();
-                        }
+                        this.revealRow(revealingRow).then(() => {
+                            this.animating = false;
+                            this.showTiles();
+
+                            // Compare normalized forms for win detection
+                            const normalizedGuess = normalizeWord(canonicalWord, normalizeMap);
+                            const normalizedTarget = normalizeWord(this.todays_word, normalizeMap);
+                            if (normalizedGuess === normalizedTarget) {
+                                this.gameWon();
+                            } else if (this.active_row === 6) {
+                                this.gameLost();
+                            }
+
+                            this.saveToLocalStorage();
+                        });
                     } else {
                         haptic.error(); // Invalid word
+                        this.shakeRow(this.active_row);
                         this.showNotification('Word is not valid');
 
                         // Track invalid word and update session frustration state
@@ -680,8 +726,10 @@ export const createGameApp = () => {
                     this.addChar(key);
                 }
 
-                this.showTiles();
-                this.saveToLocalStorage();
+                if (!this.animating) {
+                    this.showTiles();
+                    this.saveToLocalStorage();
+                }
             },
 
             showTiles(): void {
@@ -702,17 +750,118 @@ export const createGameApp = () => {
                 }
             },
 
+            revealRow(rowIndex: number): Promise<void> {
+                const FLIP_DURATION = 500;
+                const MIDPOINT = 250;
+                const STAGGER = 200;
+                const tileCount = 5;
+                const keyClasses = this.key_classes as Record<string, KeyState>;
+
+                // Get the row DOM element (nth row div inside .game-board)
+                const board = document.querySelector('.game-board');
+                const rowEl = board?.children[rowIndex] as HTMLElement | undefined;
+
+                return new Promise((resolve) => {
+                    for (let t = 0; t < tileCount; t++) {
+                        const visualIdx = this.right_to_left ? tileCount - 1 - t : t;
+                        const dataIdx = this.right_to_left ? tileCount - 1 - visualIdx : visualIdx;
+
+                        setTimeout(() => {
+                            // Apply flip animation directly to DOM element (bypasses Vue)
+                            const tileEl = rowEl?.children[visualIdx] as HTMLElement | undefined;
+                            if (tileEl) {
+                                tileEl.style.animation = `flipReveal ${FLIP_DURATION}ms ease-in-out`;
+                            }
+
+                            // At midpoint: swap color via Vue reactivity
+                            setTimeout(() => {
+                                const finalClass = this.tile_classes[rowIndex]?.[dataIdx] || '';
+                                this.tile_classes_visual[rowIndex]?.splice(
+                                    visualIdx,
+                                    1,
+                                    finalClass
+                                );
+                                const tileChar = this.tiles[rowIndex]?.[dataIdx] || '';
+                                this.tiles_visual[rowIndex]?.splice(visualIdx, 1, tileChar);
+
+                                // Update keyboard color for this tile
+                                const keyUpdate = this.pendingKeyUpdates[dataIdx];
+                                if (keyUpdate) {
+                                    this.updateKeyColor(
+                                        keyUpdate.char,
+                                        keyUpdate.state,
+                                        keyClasses
+                                    );
+                                }
+                            }, MIDPOINT);
+
+                            // Clean up after animation
+                            setTimeout(() => {
+                                if (tileEl) tileEl.style.animation = '';
+                                if (t === tileCount - 1) resolve();
+                            }, FLIP_DURATION);
+                        }, t * STAGGER);
+                    }
+                });
+            },
+
+            _nudgeKey(char: string, animClass: string): void {
+                const el = document.querySelector(`button[data-char="${CSS.escape(char)}"]`);
+                if (!el) return;
+                el.classList.remove(animClass);
+                // Force reflow to restart animation
+                void (el as HTMLElement).offsetWidth;
+                el.classList.add(animClass);
+                el.addEventListener('animationend', () => el.classList.remove(animClass), {
+                    once: true,
+                });
+            },
+
+            shakeRow(rowIndex: number): void {
+                this.shaking_row = rowIndex;
+                setTimeout(() => {
+                    this.shaking_row = -1;
+                }, 500);
+            },
+
+            bounceRow(rowIndex: number): void {
+                const STAGGER = 150;
+                const DURATION = 1000;
+                const tileCount = 5;
+
+                for (let t = 0; t < tileCount; t++) {
+                    const visualIdx = this.right_to_left ? tileCount - 1 - t : t;
+                    setTimeout(() => {
+                        const currentClass = this.tile_classes_visual[rowIndex]?.[visualIdx] || '';
+                        this.tile_classes_visual[rowIndex]?.splice(
+                            visualIdx,
+                            1,
+                            `${currentClass} tile-bounce`
+                        );
+                        setTimeout(() => {
+                            this.tile_classes_visual[rowIndex]?.splice(visualIdx, 1, currentClass);
+                        }, DURATION);
+                    }, t * STAGGER);
+                }
+            },
+
             gameWon(): void {
                 this.game_over = true;
                 this.game_won = true;
                 this.emoji_board = this.getEmojiBoard();
-                this.showNotification(this.todays_word.toUpperCase(), 12);
+                const winWord = WIN_WORDS[this.active_row - 1] || 'Phew';
+                this.showNotification(winWord, 3);
                 haptic.success(); // Celebration!
                 sound.win();
 
+                // Bounce tiles after a brief pause
+                setTimeout(() => {
+                    this.bounceRow(this.active_row - 1);
+                }, 300);
+
                 setTimeout(() => {
                     this.show_stats_modal = true;
-                }, 400);
+                }, 2500);
 
                 this.loadDefinition();
                 this.submitWordStats(true, this.active_row);
@@ -760,7 +909,7 @@ export const createGameApp = () => {
 
                 setTimeout(() => {
                     this.show_stats_modal = true;
-                }, 400);
+                }, 1800);
 
                 this.loadDefinition();
                 this.submitWordStats(false, this.active_row);
@@ -812,20 +961,28 @@ export const createGameApp = () => {
             showNotification(message: string, duration = 3): void {
                 if (this.notification.show) {
                     clearTimeout(this.notification.timeout);
+                    clearTimeout(this.notification.fadeTimeout);
+                    clearInterval(this.notification.slideInterval);
                 }
 
                 this.notification.show = true;
+                this.notification.fading = false;
                 this.notification.message = message;
                 this.notification.top = 0;
 
                 this.notification.timeout = window.setTimeout(() => {
-                    this.notification.show = false;
+                    this.notification.fading = true;
+                    this.notification.fadeTimeout = window.setTimeout(() => {
+                        this.notification.show = false;
+                        this.notification.fading = false;
+                    }, 300);
                 }, duration * 1000);
 
-                // Animate notification down
-                const interval = window.setInterval(() => {
+                this.notification.slideInterval = window.setInterval(() => {
                     this.notification.top += 1;
-                    if (this.notification.top > 50) clearInterval(interval);
+                    if (this.notification.top > 50) {
+                        clearInterval(this.notification.slideInterval);
+                    }
                 }, 2);
             },
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -52,16 +52,33 @@
     @apply opacity-70;
 }
 
+/* Keyboard key shake for wasted guess (already known letter) */
+@keyframes key-shake {
+    0%, 100% { transform: translateX(0); }
+    20%, 60% { transform: translateX(-2px); }
+    40%, 80% { transform: translateX(2px); }
+}
+
 .key-correct {
     @apply bg-green-500 text-white;
+    animation: key-pop 200ms ease-out;
 }
 
 .key-semicorrect {
     @apply bg-yellow-500 text-white;
+    animation: key-pop 200ms ease-out;
 }
 
 .key-incorrect {
     @apply bg-neutral-500 text-white;
+}
+
+.key-shake {
+    animation: key-shake 400ms ease-in-out;
+}
+
+.key-pulse {
+    animation: key-pop 300ms ease-out;
 }
 
 /* Safe area insets for notched devices */
@@ -136,27 +153,58 @@
     color: #2d6a4f;
 }
 
+/* Modal fade-in */
+@keyframes modalIn {
+    from { opacity: 0; transform: scale(0.95) translateY(8px); }
+    to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.modal-animate {
+    animation: modalIn 200ms ease-out;
+}
+
 /* Prevent text selection on game elements */
 .no-select {
     user-select: none;
     -webkit-user-select: none;
 }
 
-/* Flip animation for tiles */
-@keyframes flip {
-    0% {
-        transform: rotateX(0);
-    }
-    50% {
-        transform: rotateX(90deg);
-    }
-    100% {
-        transform: rotateX(0);
-    }
+/* 3D perspective for tile flip */
+.game-board {
+    perspective: 1000px;
 }
 
-.flip {
-    animation: flip 0.5s ease-in-out;
+/* Single smooth flip — color swaps at midpoint (90deg, tile invisible) */
+@keyframes flipReveal {
+    0% { transform: rotateX(0deg); }
+    50% { transform: rotateX(90deg); }
+    100% { transform: rotateX(0deg); }
+}
+
+/* Win celebration bounce with Pixar-style squash & stretch */
+@keyframes tile-bounce {
+    0%   { transform: translateY(0); }
+    8%   { transform: translateY(2px)   scale(1.12, 0.82); }
+    22%  { transform: translateY(-44px) scale(0.82, 1.18); }
+    32%  { transform: translateY(-48px) scale(0.95, 1.05); }
+    50%  { transform: translateY(0)     scale(1, 1); }
+    54%  { transform: translateY(2px)   scale(1.1, 0.86); }
+    66%  { transform: translateY(-18px) scale(0.9, 1.1); }
+    78%  { transform: translateY(0)     scale(1, 1); }
+    82%  { transform: translateY(1px)   scale(1.04, 0.96); }
+    90%  { transform: translateY(-5px)  scale(0.98, 1.02); }
+    100% { transform: translateY(0)     scale(1, 1); }
+}
+
+.tile-bounce {
+    animation: tile-bounce 1000ms ease;
+}
+
+/* Keyboard key pop when color is revealed */
+@keyframes key-pop {
+    0%   { transform: scale(1); }
+    40%  { transform: scale(1.2); }
+    100% { transform: scale(1); }
 }
 
 /* Shake animation for invalid words */
@@ -173,10 +221,15 @@
 /* Pop animation for typed letters */
 @keyframes pop {
     0% { transform: scale(1); }
-    50% { transform: scale(1.1); }
+    40% { transform: scale(1.12); }
     100% { transform: scale(1); }
 }
 
 .pop {
-    animation: pop 0.1s ease-in-out;
+    animation: pop 100ms ease-out;
+    border-color: #878a8c !important;
+}
+
+.dark .pop {
+    border-color: #565758 !important;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -82,9 +82,12 @@ export interface GameData {
 
 export interface Notification {
     show: boolean;
+    fading: boolean;
     message: string;
     top: number;
     timeout: number;
+    fadeTimeout: number;
+    slideInterval: number;
 }
 
 export type GuessDistribution = Record<1 | 2 | 3 | 4 | 5 | 6, number>;

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -175,9 +175,9 @@
                 <!-- The game board -->
                 <main class="flex flex-auto justify-center items-center">
                     <div
-                        class="grid grid-rows-6 relative w-full h-full max-w-[350px] max-h-[420px] gap-1 p-3 box-border">
+                        class="game-board grid grid-rows-6 relative w-full h-full max-w-[350px] max-h-[420px] gap-1 p-3 box-border">
                         {% for i in range(6) %}
-                        <div class="grid grid-cols-5 gap-1 w-full">
+                        <div class="grid grid-cols-5 gap-1 w-full" v-bind:class="{ shake: shaking_row === {{i}} }">
                             {% for j in range(5) %}
                             <div class="w-full h-full justify-center items-center inline-flex "
                                 v-html="[[ tiles_visual[{{i}}][{{j}}] ]]"
@@ -219,7 +219,7 @@
             <!-- <div v-if="showHelpModal" class="opacity-25 fixed top-0 left-0 w-full h-full z-1 bg-black"></div> -->
             <div id="HelpModal" v-show="showHelpModal"
                 class="fixed top-10 left-0 w-full h-full z-50 items-center flex mx-auto " v-cloak>
-                <div class="bg-white dark:bg-neutral-800 rounded-lg shadow-lg p-5 m-4 border-2 border-slate-200 dark:border-neutral-600 mx-auto w-full max-w-md sm:max-w-lg"
+                <div class="modal-animate bg-white dark:bg-neutral-800 rounded-lg shadow-lg p-5 m-4 border-2 border-slate-200 dark:border-neutral-600 mx-auto w-full max-w-md sm:max-w-lg"
                     v-cloak>
                     <div class="flex flex-col gap-2 relative">
 
@@ -333,7 +333,7 @@
             <!-- options modal -->
             <div v-show="show_options_modal" class="fixed top-10 left-0 w-full h-full z-30 items-center mx-auto flex
             " v-cloak>
-                <div class="bg-white dark:bg-neutral-800 rounded-lg shadow-lg p-5 m-4 border-2 border-slate-200 dark:border-neutral-600 mx-auto w-full max-w-xs sm:max-w-md"
+                <div class="modal-animate bg-white dark:bg-neutral-800 rounded-lg shadow-lg p-5 m-4 border-2 border-slate-200 dark:border-neutral-600 mx-auto w-full max-w-xs sm:max-w-md"
                     v-cloak>
                     <div class="flex flex-col gap-2 relative">
                         <button type="button" v-on:click="show_options_modal = false" aria-label="Close" class="absolute top-0 right-0 p-1 ml-auto z-50">
@@ -443,7 +443,7 @@
 
         <!-- stats modal -->
         <div v-show="show_stats_modal" class="fixed top-10 left-0 w-full h-full z-50 items-center flex" v-cloak>
-            <div class="relative mx-auto w-full max-w-lg z-50 border-2 border-slate-200 dark:border-neutral-600 rounded-xl max-h-[85vh] overflow-y-auto" v-cloak>
+            <div class="modal-animate relative mx-auto w-full max-w-lg z-50 border-2 border-slate-200 dark:border-neutral-600 rounded-xl max-h-[85vh] overflow-y-auto" v-cloak>
                 <div
                     class="border-0 rounded-lg drop-shadow-xl relative flex flex-col w-full bg-white dark:bg-neutral-800 outline-none focus:outline-none">
 
@@ -648,10 +648,11 @@
         </div>
 
 
-        <!-- alert that floats slowly down from top and closes after 3 seconds -->
+        <!-- Toast notification -->
         <div v-if="notification.show"
-            class="fixed top-0 inset-x-0 mx-auto z-50 max-w-xs justify-items-center text-center" v-cloak>
-            <div class="top-50 bg-black p-4 m-4 rounded-lg shadow-lg animate-pulse" v-cloak
+            class="fixed top-0 inset-x-0 mx-auto z-50 max-w-xs justify-items-center text-center transition-opacity duration-300"
+            v-bind:class="{ 'opacity-0': notification.fading }" v-cloak>
+            <div class="top-50 bg-black p-4 m-4 rounded-lg shadow-lg" v-cloak
                 v-bind:style="{'top': notification.top + 'px'}">
                 <p class="font-bold text-white">[[ notification.message ]]</p>
             </div>


### PR DESCRIPTION
## Summary
Adds the signature Wordle animations and micro-interactions that were missing:

- **Staggered tile flip** — tiles reveal colors one by one (500ms flip, 200ms stagger), color swaps at midpoint when tile is edge-on
- **Win tile bounce** — Pixar-style squash & stretch wave animation after winning
- **Row shake** — invalid/incomplete word shakes the row (existing CSS, now wired up)
- **Keyboard per-tile updates** — keys change color as each tile flips, not all at once
- **Key feedback** — green/yellow keys pop on reveal; already-grey keys shake when re-guessed
- **Win words** — "Genius", "Magnificent", "Impressive", "Splendid", "Great", "Phew"
- **Toast fade-out** — 300ms opacity transition instead of instant disappear
- **Modal fade-in** — 200ms scale + translate animation on all modals
- **Tile pop border** — darker border on letter entry for clearer input feedback
- **Stats modal delay** — 2.5s on win, 1.8s on loss (lets animations complete)

Also includes code quality fixes from `/simplify` review: notification race fix, CSS.escape in selectors, proper TypeScript types, dead code removal.

## Test plan
- [ ] Type letters → pop animation + darker border
- [ ] Submit incomplete word → row shakes
- [ ] Submit invalid word → row shakes + haptic + toast
- [ ] Submit valid word → tiles flip one by one, keyboard updates per-tile
- [ ] Re-guess eliminated letter → grey key shakes
- [ ] Win → flip → bounce wave → "Genius"/"Phew" toast → stats modal at ~2.5s
- [ ] Lose → flip → word toast → stats modal at ~1.8s
- [ ] Toast fades out smoothly
- [ ] Modals scale-fade in
- [ ] RTL language (/he, /ar) → tiles flip right to left
- [ ] Reload mid-game → no animation replay
- [ ] Can't type during flip animation
- [ ] Dark mode: border colors correct on pop

@coderabbitai review