### PR TITLE
Add auto-tutorial, hard mode, and colorblind mode

### DIFF
--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -82,7 +82,15 @@ interface InvalidWordParams {
 }
 
 interface SettingsChangeParams {
-    setting: 'dark_mode' | 'haptics' | 'sound' | 'feedback' | 'word_info' | 'definitions';
+    setting:
+        | 'dark_mode'
+        | 'haptics'
+        | 'sound'
+        | 'feedback'
+        | 'word_info'
+        | 'definitions'
+        | 'hard_mode'
+        | 'high_contrast';
     value: boolean;
 }
 

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -1487,6 +1487,22 @@ export const createGameApp = () => {
                 });
             },
 
+            setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
+                // Don't allow switching TO hard mode mid-game
+                if (level === 'hard' && this.active_row > 0 && !this.game_over) return;
+                this.allow_any_word = level === 'easy';
+                this.hardMode = level === 'hard';
+                try {
+                    localStorage.setItem('hardMode', this.hardMode ? 'true' : 'false');
+                } catch {
+                    // localStorage unavailable
+                }
+                analytics.trackSettingsChange({
+                    setting: 'hard_mode',
+                    value: this.hardMode,
+                });
+            },
+
             /**
              * Validate a guess against hard mode rules.
              * Returns an error message if invalid, or null if valid.

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -129,6 +129,8 @@ interface GameData {
     communityStatsLink: string | null;
     hardMode: boolean;
     highContrast: boolean;
+    difficultyShake: boolean;
+    difficultyWarning: boolean;
 }
 
 export const createGameApp = () => {
@@ -166,6 +168,8 @@ export const createGameApp = () => {
                 pendingKeyUpdates: [] as Array<{ char: string; state: KeyState } | undefined>,
                 hardMode: false,
                 highContrast: false,
+                difficultyShake: false,
+                difficultyWarning: false,
 
                 notification: {
                     show: false,
@@ -1488,11 +1492,16 @@ export const createGameApp = () => {
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Don't allow switching TO hard mode mid-game — snap back with warning
+                // Don't allow switching TO hard mode mid-game — shake and show warning
                 if (level === 'hard' && this.active_row > 0 && !this.game_over) {
-                    this.showNotification('Hard mode can only be enabled before your first guess');
+                    this.difficultyShake = true;
+                    this.difficultyWarning = true;
+                    setTimeout(() => {
+                        this.difficultyShake = false;
+                    }, 500);
                     return;
                 }
+                this.difficultyWarning = false;
                 this.allow_any_word = level === 'easy';
                 this.hardMode = level === 'hard';
                 try {

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -1492,13 +1492,18 @@ export const createGameApp = () => {
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Don't allow changing difficulty mid-game — shake and show warning
+                // Can go easier mid-game but not harder
+                const levels = { easy: 0, normal: 1, hard: 2 };
                 const currentLevel = this.hardMode
                     ? 'hard'
                     : this.allow_any_word
                       ? 'easy'
                       : 'normal';
-                if (level !== currentLevel && this.active_row > 0 && !this.game_over) {
+                if (
+                    levels[level] > levels[currentLevel] &&
+                    this.active_row > 0 &&
+                    !this.game_over
+                ) {
                     this.difficultyShake = true;
                     this.difficultyWarning = true;
                     setTimeout(() => {

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -1488,8 +1488,11 @@ export const createGameApp = () => {
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Don't allow switching TO hard mode mid-game
-                if (level === 'hard' && this.active_row > 0 && !this.game_over) return;
+                // Don't allow switching TO hard mode mid-game — snap back with warning
+                if (level === 'hard' && this.active_row > 0 && !this.game_over) {
+                    this.showNotification('Hard mode can only be enabled before your first guess');
+                    return;
+                }
                 this.allow_any_word = level === 'easy';
                 this.hardMode = level === 'hard';
                 try {

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -1533,6 +1533,14 @@ export const createGameApp = () => {
              * Returns an error message if invalid, or null if valid.
              */
             checkHardMode(guess: string): string | null {
+                // Normalize a char for comparison (diacritics + positional variants)
+                const norm = (char: string): string => {
+                    const positionalNorm = toRegularForm(char, finalFormReverseMap);
+                    return (normalizeMap.get(positionalNorm) || positionalNorm).toLowerCase();
+                };
+
+                const guessNorm = [...guess].map(norm);
+
                 // Check all previously submitted rows for hints
                 for (let r = 0; r < this.active_row; r++) {
                     const row = this.tiles[r];
@@ -1544,18 +1552,20 @@ export const createGameApp = () => {
                         const letter = row[c];
                         if (!letter) continue;
 
+                        const letterNorm = norm(letter);
+
                         if (
                             tileClass.includes('correct') &&
                             !tileClass.includes('semicorrect') &&
                             !tileClass.includes('incorrect')
                         ) {
                             // Green: must be in the same position
-                            if (guess[c]?.toLowerCase() !== letter.toLowerCase()) {
+                            if (guessNorm[c] !== letterNorm) {
                                 return `Hard mode: ${letter.toUpperCase()} must be in position ${c + 1}`;
                             }
                         } else if (tileClass.includes('semicorrect')) {
                             // Yellow: must appear somewhere in the guess
-                            if (!guess.toLowerCase().includes(letter.toLowerCase())) {
+                            if (!guessNorm.includes(letterNorm)) {
                                 return `Hard mode: guess must contain ${letter.toUpperCase()}`;
                             }
                         }

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -353,10 +353,10 @@ export const createGameApp = () => {
             this.loadLanguages();
             this.loadFeedbackPreference();
             this.loadWordInfoPreference();
-            this.loadHardModePreference();
+            this.loadDifficultyPreference();
             this.loadHighContrastPreference();
             // Set max difficulty based on current setting (if game in progress, this is what they started at)
-            this.maxDifficultyUsed = this.hardMode ? 2 : this.allow_any_word ? 0 : 1;
+            this.maxDifficultyUsed = this.currentDifficultyLevel();
             this.stats = this.calculateStats(this.config?.language_code);
             this.total_stats = this.calculateTotalStats();
             this.time_until_next_day = this.getTimeUntilNextDay();
@@ -704,9 +704,10 @@ export const createGameApp = () => {
 
                         this.updateColors();
                         // Track highest difficulty a guess was submitted at
-                        const diffLevels = { easy: 0, normal: 1, hard: 2 };
-                        const currentDiff = this.hardMode ? 2 : this.allow_any_word ? 0 : 1;
-                        this.maxDifficultyUsed = Math.max(this.maxDifficultyUsed, currentDiff);
+                        this.maxDifficultyUsed = Math.max(
+                            this.maxDifficultyUsed,
+                            this.currentDifficultyLevel()
+                        );
                         const revealingRow = this.active_row;
                         this.active_row++;
                         this.active_cell = 0;
@@ -1474,34 +1475,32 @@ export const createGameApp = () => {
                 }
             },
 
-            loadHardModePreference(): void {
+            loadDifficultyPreference(): void {
                 try {
-                    const stored = localStorage.getItem('hardMode');
-                    if (stored !== null) {
-                        this.hardMode = stored === 'true';
+                    const storedHard = localStorage.getItem('hardMode');
+                    if (storedHard !== null) {
+                        this.hardMode = storedHard === 'true';
+                    }
+                    const storedEasy = localStorage.getItem('allowAnyWord');
+                    if (storedEasy !== null) {
+                        this.allow_any_word = storedEasy === 'true';
+                    }
+                    // Can't be both
+                    if (this.hardMode && this.allow_any_word) {
+                        this.allow_any_word = false;
                     }
                 } catch {
                     // localStorage unavailable
                 }
             },
 
-            toggleHardMode(): void {
-                this.$nextTick(() => {
-                    try {
-                        localStorage.setItem('hardMode', this.hardMode ? 'true' : 'false');
-                    } catch {
-                        // localStorage unavailable
-                    }
-                    analytics.trackSettingsChange({
-                        setting: 'hard_mode',
-                        value: this.hardMode,
-                    });
-                });
+            currentDifficultyLevel(): number {
+                return this.hardMode ? 2 : this.allow_any_word ? 0 : 1;
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Can't go higher than the max difficulty any guess was submitted at
                 const levels = { easy: 0, normal: 1, hard: 2 };
+                // Can't go higher than the max difficulty any guess was submitted at
                 if (
                     levels[level] > this.maxDifficultyUsed &&
                     this.active_row > 0 &&
@@ -1519,6 +1518,7 @@ export const createGameApp = () => {
                 this.hardMode = level === 'hard';
                 try {
                     localStorage.setItem('hardMode', this.hardMode ? 'true' : 'false');
+                    localStorage.setItem('allowAnyWord', this.allow_any_word ? 'true' : 'false');
                 } catch {
                     // localStorage unavailable
                 }

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -1492,8 +1492,13 @@ export const createGameApp = () => {
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Don't allow switching TO hard mode mid-game — shake and show warning
-                if (level === 'hard' && this.active_row > 0 && !this.game_over) {
+                // Don't allow changing difficulty mid-game — shake and show warning
+                const currentLevel = this.hardMode
+                    ? 'hard'
+                    : this.allow_any_word
+                      ? 'easy'
+                      : 'normal';
+                if (level !== currentLevel && this.active_row > 0 && !this.game_over) {
                     this.difficultyShake = true;
                     this.difficultyWarning = true;
                     setTimeout(() => {

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -127,6 +127,8 @@ interface GameData {
     communityIsTopScore: boolean;
     communityTotal: number;
     communityStatsLink: string | null;
+    hardMode: boolean;
+    highContrast: boolean;
 }
 
 export const createGameApp = () => {
@@ -162,6 +164,8 @@ export const createGameApp = () => {
                 animating: false,
                 shaking_row: -1,
                 pendingKeyUpdates: [] as Array<{ char: string; state: KeyState } | undefined>,
+                hardMode: false,
+                highContrast: false,
 
                 notification: {
                     show: false,
@@ -343,6 +347,8 @@ export const createGameApp = () => {
             this.loadLanguages();
             this.loadFeedbackPreference();
             this.loadWordInfoPreference();
+            this.loadHardModePreference();
+            this.loadHighContrastPreference();
             this.stats = this.calculateStats(this.config?.language_code);
             this.total_stats = this.calculateTotalStats();
             this.time_until_next_day = this.getTimeUntilNextDay();
@@ -392,6 +398,9 @@ export const createGameApp = () => {
                         ? this.attempts
                         : parseInt(String(this.attempts), 10) || 0;
                 this.submitWordStats(this.game_won, attempts);
+            } else {
+                // Auto-show tutorial on first visit for this language
+                this.maybeShowTutorial();
             }
         },
 
@@ -654,6 +663,17 @@ export const createGameApp = () => {
                     const canonicalWord = this.checkWord(typedWord);
 
                     if (canonicalWord) {
+                        // Hard mode validation: revealed hints must be used
+                        if (this.hardMode) {
+                            const hardModeError = this.checkHardMode(canonicalWord);
+                            if (hardModeError) {
+                                haptic.error();
+                                this.shakeRow(this.active_row);
+                                this.showNotification(hardModeError);
+                                return;
+                            }
+                        }
+
                         haptic.confirm(); // Valid word submitted
 
                         // Reset consecutive invalid counter on valid word
@@ -988,6 +1008,8 @@ export const createGameApp = () => {
 
             getEmojiBoard(): string {
                 let board = '';
+                const greenEmoji = this.highContrast ? '🟦' : '🟩';
+                const yellowEmoji = this.highContrast ? '🟧' : '🟨';
                 for (let i = 0; i < this.tile_classes.length; i++) {
                     const row = this.tile_classes[i];
                     if (!row) continue;
@@ -998,9 +1020,9 @@ export const createGameApp = () => {
                             !tileClass.includes('semicorrect') &&
                             !tileClass.includes('incorrect')
                         ) {
-                            board += '🟩';
+                            board += greenEmoji;
                         } else if (tileClass.includes('semicorrect')) {
-                            board += '🟨';
+                            board += yellowEmoji;
                         } else if (tileClass.includes('incorrect')) {
                             board += '⬜';
                         } else {
@@ -1333,7 +1355,8 @@ export const createGameApp = () => {
 
             getShareText(): string {
                 const name = this.config?.name_native || this.config?.language_code || '';
-                return `Wordle ${name} #${this.todays_idx} — ${this.attempts}/6\n\n${this.emoji_board}`;
+                const hardModeFlag = this.hardMode ? ' *' : '';
+                return `Wordle ${name} #${this.todays_idx} — ${this.attempts}/6${hardModeFlag}\n\n${this.emoji_board}`;
             },
 
             toggleDarkMode(): void {
@@ -1418,6 +1441,116 @@ export const createGameApp = () => {
                     if (this.wordInfoEnabled && this.game_over) {
                         this.loadDefinition();
                     }
+                });
+            },
+
+            maybeShowTutorial(): void {
+                const langCode = this.config?.language_code || 'unknown';
+                try {
+                    const tutorialKey = `tutorial_shown_${langCode}`;
+                    if (localStorage.getItem(tutorialKey)) return;
+
+                    // Check if there's existing game state for this language
+                    const pageName = window.location.pathname.split('/').pop() || 'home';
+                    const hasGameState = localStorage.getItem(pageName);
+                    if (hasGameState) return;
+
+                    this.showHelpModal = true;
+                    localStorage.setItem(tutorialKey, 'true');
+                } catch {
+                    // localStorage unavailable
+                }
+            },
+
+            loadHardModePreference(): void {
+                try {
+                    const stored = localStorage.getItem('hardMode');
+                    if (stored !== null) {
+                        this.hardMode = stored === 'true';
+                    }
+                } catch {
+                    // localStorage unavailable
+                }
+            },
+
+            toggleHardMode(): void {
+                this.$nextTick(() => {
+                    try {
+                        localStorage.setItem('hardMode', this.hardMode ? 'true' : 'false');
+                    } catch {
+                        // localStorage unavailable
+                    }
+                    analytics.trackSettingsChange({
+                        setting: 'hard_mode',
+                        value: this.hardMode,
+                    });
+                });
+            },
+
+            /**
+             * Validate a guess against hard mode rules.
+             * Returns an error message if invalid, or null if valid.
+             */
+            checkHardMode(guess: string): string | null {
+                // Check all previously submitted rows for hints
+                for (let r = 0; r < this.active_row; r++) {
+                    const row = this.tiles[r];
+                    const classes = this.tile_classes[r];
+                    if (!row || !classes) continue;
+
+                    for (let c = 0; c < row.length; c++) {
+                        const tileClass = classes[c] || '';
+                        const letter = row[c];
+                        if (!letter) continue;
+
+                        if (
+                            tileClass.includes('correct') &&
+                            !tileClass.includes('semicorrect') &&
+                            !tileClass.includes('incorrect')
+                        ) {
+                            // Green: must be in the same position
+                            if (guess[c]?.toLowerCase() !== letter.toLowerCase()) {
+                                return `Hard mode: ${letter.toUpperCase()} must be in position ${c + 1}`;
+                            }
+                        } else if (tileClass.includes('semicorrect')) {
+                            // Yellow: must appear somewhere in the guess
+                            if (!guess.toLowerCase().includes(letter.toLowerCase())) {
+                                return `Hard mode: guess must contain ${letter.toUpperCase()}`;
+                            }
+                        }
+                    }
+                }
+                return null;
+            },
+
+            loadHighContrastPreference(): void {
+                try {
+                    const stored = localStorage.getItem('highContrast');
+                    if (stored === 'true') {
+                        this.highContrast = true;
+                        document.documentElement.classList.add('high-contrast');
+                    }
+                } catch {
+                    // localStorage unavailable
+                }
+            },
+
+            toggleHighContrast(): void {
+                this.$nextTick(() => {
+                    if (this.highContrast) {
+                        document.documentElement.classList.add('high-contrast');
+                    } else {
+                        document.documentElement.classList.remove('high-contrast');
+                    }
+                    try {
+                        localStorage.setItem('highContrast', this.highContrast ? 'true' : 'false');
+                    } catch {
+                        // localStorage unavailable
+                    }
+                    analytics.trackSettingsChange({
+                        setting: 'high_contrast',
+                        value: this.highContrast,
+                    });
                 });
             },
 

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -131,6 +131,7 @@ interface GameData {
     highContrast: boolean;
     difficultyShake: boolean;
     difficultyWarning: boolean;
+    maxDifficultyUsed: number;
 }
 
 export const createGameApp = () => {
@@ -170,6 +171,7 @@ export const createGameApp = () => {
                 highContrast: false,
                 difficultyShake: false,
                 difficultyWarning: false,
+                maxDifficultyUsed: 1, // 0=easy, 1=normal, 2=hard — tracks highest level any guess was made at
 
                 notification: {
                     show: false,
@@ -353,6 +355,8 @@ export const createGameApp = () => {
             this.loadWordInfoPreference();
             this.loadHardModePreference();
             this.loadHighContrastPreference();
+            // Set max difficulty based on current setting (if game in progress, this is what they started at)
+            this.maxDifficultyUsed = this.hardMode ? 2 : this.allow_any_word ? 0 : 1;
             this.stats = this.calculateStats(this.config?.language_code);
             this.total_stats = this.calculateTotalStats();
             this.time_until_next_day = this.getTimeUntilNextDay();
@@ -699,6 +703,10 @@ export const createGameApp = () => {
                         }
 
                         this.updateColors();
+                        // Track highest difficulty a guess was submitted at
+                        const diffLevels = { easy: 0, normal: 1, hard: 2 };
+                        const currentDiff = this.hardMode ? 2 : this.allow_any_word ? 0 : 1;
+                        this.maxDifficultyUsed = Math.max(this.maxDifficultyUsed, currentDiff);
                         const revealingRow = this.active_row;
                         this.active_row++;
                         this.active_cell = 0;
@@ -1492,15 +1500,10 @@ export const createGameApp = () => {
             },
 
             setDifficulty(level: 'easy' | 'normal' | 'hard'): void {
-                // Can go easier mid-game but not harder
+                // Can't go higher than the max difficulty any guess was submitted at
                 const levels = { easy: 0, normal: 1, hard: 2 };
-                const currentLevel = this.hardMode
-                    ? 'hard'
-                    : this.allow_any_word
-                      ? 'easy'
-                      : 'normal';
                 if (
-                    levels[level] > levels[currentLevel] &&
+                    levels[level] > this.maxDifficultyUsed &&
                     this.active_row > 0 &&
                     !this.game_over
                 ) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -21,6 +21,15 @@
     @apply bg-neutral-500;
 }
 
+/* High contrast / colorblind mode overrides */
+.high-contrast .correct {
+    background-color: #85c0f9;
+}
+
+.high-contrast .semicorrect {
+    background-color: #f5793a;
+}
+
 /* Keyboard key states */
 .key {
     @apply bg-neutral-200 text-black;
@@ -72,6 +81,16 @@
 .key-incorrect {
     @apply bg-neutral-500 text-white;
 }
+
+/* High contrast keyboard key overrides */
+.high-contrast .key-correct {
+    background-color: #85c0f9;
+}
+
+.high-contrast .key-semicorrect {
+    background-color: #f5793a;
+}
+
 
 .key-shake {
     animation: key-shake 400ms ease-in-out;

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -372,7 +372,8 @@
                             <!-- Difficulty selector (3-way: Easy / Normal / Hard) -->
                             <div>
                                 <p class="text-sm font-semibold mb-2">{{ language.config.ui.difficulty or "Difficulty" }}</p>
-                                <div class="flex rounded-lg overflow-hidden border border-neutral-300 dark:border-neutral-600">
+                                <div class="flex rounded-lg overflow-hidden border border-neutral-300 dark:border-neutral-600"
+                                     :class="{ shake: difficultyShake }">
                                     <button type="button"
                                         v-on:click="setDifficulty('easy')"
                                         class="flex-1 py-2 px-1 text-xs font-medium transition-colors"
@@ -404,6 +405,8 @@
                                    v-if="!allow_any_word && !hardMode">Guesses must be valid words from the dictionary</p>
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
+                                <p class="text-xs text-amber-500 mt-1"
+                                   v-if="difficultyWarning">Hard mode can only be enabled before your first guess</p>
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -406,7 +406,7 @@
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
                                 <p class="text-xs text-amber-500 mt-1"
-                                   v-if="difficultyWarning">Hard mode can only be enabled before your first guess</p>
+                                   v-if="difficultyWarning">Difficulty can only be changed before your first guess</p>
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -404,6 +404,8 @@
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="allow_any_word && !hardMode">Any word accepted, even if not in the dictionary</p>
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
+                                   v-if="!allow_any_word && !hardMode">Guesses must be valid words from the dictionary</p>
+                                <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
                                 <p class="text-xs text-amber-500 mt-1"
                                    v-if="active_row > 0 && !game_over && !hardMode">Hard mode can be enabled before your first guess tomorrow</p>

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -369,6 +369,44 @@
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
+                            <!-- Hard mode toggle -->
+                            <div class="flex flex-row items-center">
+                                <div class="flex-grow">
+                                    <p :class="{ 'opacity-50': active_row > 0 && !game_over }">Hard Mode</p>
+                                    <p class="text-xs text-neutral-500 dark:text-neutral-400"
+                                       :class="{ 'opacity-50': active_row > 0 && !game_over }">Revealed hints must be used</p>
+                                </div>
+                                <label class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors"
+                                    :class="[
+                                        hardMode ? 'bg-green-500' : 'bg-neutral-300 dark:bg-neutral-600',
+                                        active_row > 0 && !game_over ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                                    ]">
+                                    <input
+                                        type="checkbox"
+                                        switch
+                                        class="sr-only peer"
+                                        :checked="hardMode"
+                                        :disabled="active_row > 0 && !game_over"
+                                        v-on:change="hardMode = $event.target.checked; toggleHardMode()"
+                                        aria-label="Hard Mode">
+                                    <span
+                                        class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform pointer-events-none"
+                                        :class="hardMode ? 'translate-x-6' : 'translate-x-1'">
+                                    </span>
+                                </label>
+                            </div>
+
+                            <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
+                            <!-- High Contrast / Colorblind mode toggle -->
+                            <div class="flex flex-row items-center">
+                                <div class="flex-grow">
+                                    <p>High Contrast</p>
+                                    <p class="text-xs text-neutral-500 dark:text-neutral-400">Colorblind-friendly colors</p>
+                                </div>
+                                {{ toggle_switch('highContrast', 'toggleHighContrast()', 'High Contrast') }}
+                            </div>
+
+                            <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
                             <!-- toggle button for right_to_left -->
                             <div class="flex flex-row">
                                 <p class="flex-grow">{{ language.config.ui.right_to_left or "Right to left" }}</p>

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -392,12 +392,9 @@
                                     <button type="button"
                                         v-on:click="setDifficulty('hard')"
                                         class="flex-1 py-2 px-1 text-xs font-medium transition-colors"
-                                        :class="[
-                                            hardMode
-                                                ? 'bg-green-500 text-white'
-                                                : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600',
-                                            active_row > 0 && !game_over && !hardMode ? 'opacity-40 cursor-not-allowed' : ''
-                                        ]">
+                                        :class="hardMode
+                                            ? 'bg-green-500 text-white'
+                                            : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'">
                                         Hard
                                     </button>
                                 </div>
@@ -407,8 +404,6 @@
                                    v-if="!allow_any_word && !hardMode">Guesses must be valid words from the dictionary</p>
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
-                                <p class="text-xs text-amber-500 mt-1"
-                                   v-if="active_row > 0 && !game_over && !hardMode">Hard mode can be enabled before your first guess tomorrow</p>
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -369,31 +369,44 @@
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
-                            <!-- Hard mode toggle -->
-                            <div class="flex flex-row items-center">
-                                <div class="flex-grow">
-                                    <p :class="{ 'opacity-50': active_row > 0 && !game_over }">Hard Mode</p>
-                                    <p class="text-xs text-neutral-500 dark:text-neutral-400"
-                                       :class="{ 'opacity-50': active_row > 0 && !game_over }">Revealed hints must be used</p>
+                            <!-- Difficulty selector (3-way: Easy / Normal / Hard) -->
+                            <div>
+                                <p class="text-sm font-semibold mb-2">{{ language.config.ui.difficulty or "Difficulty" }}</p>
+                                <div class="flex rounded-lg overflow-hidden border border-neutral-300 dark:border-neutral-600">
+                                    <button type="button"
+                                        v-on:click="setDifficulty('easy')"
+                                        class="flex-1 py-2 px-1 text-xs font-medium transition-colors"
+                                        :class="allow_any_word && !hardMode
+                                            ? 'bg-green-500 text-white'
+                                            : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'">
+                                        Easy
+                                    </button>
+                                    <button type="button"
+                                        v-on:click="setDifficulty('normal')"
+                                        class="flex-1 py-2 px-1 text-xs font-medium transition-colors border-x border-neutral-300 dark:border-neutral-600"
+                                        :class="!allow_any_word && !hardMode
+                                            ? 'bg-green-500 text-white'
+                                            : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600'">
+                                        Normal
+                                    </button>
+                                    <button type="button"
+                                        v-on:click="setDifficulty('hard')"
+                                        class="flex-1 py-2 px-1 text-xs font-medium transition-colors"
+                                        :class="[
+                                            hardMode
+                                                ? 'bg-green-500 text-white'
+                                                : 'bg-neutral-100 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-600',
+                                            active_row > 0 && !game_over && !hardMode ? 'opacity-40 cursor-not-allowed' : ''
+                                        ]">
+                                        Hard
+                                    </button>
                                 </div>
-                                <label class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors"
-                                    :class="[
-                                        hardMode ? 'bg-green-500' : 'bg-neutral-300 dark:bg-neutral-600',
-                                        active_row > 0 && !game_over ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                                    ]">
-                                    <input
-                                        type="checkbox"
-                                        switch
-                                        class="sr-only peer"
-                                        :checked="hardMode"
-                                        :disabled="active_row > 0 && !game_over"
-                                        v-on:change="hardMode = $event.target.checked; toggleHardMode()"
-                                        aria-label="Hard Mode">
-                                    <span
-                                        class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform pointer-events-none"
-                                        :class="hardMode ? 'translate-x-6' : 'translate-x-1'">
-                                    </span>
-                                </label>
+                                <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
+                                   v-if="allow_any_word && !hardMode">Any word accepted, even if not in the dictionary</p>
+                                <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
+                                   v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
+                                <p class="text-xs text-amber-500 mt-1"
+                                   v-if="active_row > 0 && !game_over && !hardMode">Hard mode can be enabled before your first guess tomorrow</p>
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
@@ -451,12 +464,6 @@
                             </form>
                             {% endif %}
 
-                            <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>
-                            <div class="flex flex-row">
-                                <p class="flex-grow">{{ language.config.ui.easy_mode or "Allow any word" }} (<span class="italic">{{ language.config.ui.easy_mode_label or "easy mode" }}</span>)</p>
-                                <!-- toggle at the end -->
-                                <input type="checkbox" v-model="allow_any_word" />
-                            </div>
 
 
                             <!-- Install App button (only shown when not already installed) -->

--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -406,7 +406,7 @@
                                 <p class="text-xs text-neutral-500 dark:text-neutral-400 mt-1"
                                    v-if="hardMode">Revealed hints must be used in subsequent guesses</p>
                                 <p class="text-xs text-amber-500 mt-1"
-                                   v-if="difficultyWarning">Difficulty can only be changed before your first guess</p>
+                                   v-if="difficultyWarning">Difficulty can only be increased before your first guess</p>
                             </div>
 
                             <div class="border-t-2 border-gray-300 dark:border-gray-600"></div>


### PR DESCRIPTION
## Summary
Three quick-win features that every major Wordle competitor has and we didn't:

**1. Auto-show tutorial on first visit**
- Checks localStorage for existing game state
- Shows the help modal automatically for new users (once per language)
- Addresses the ~20% landing page bounce from confused first-time visitors

**2. Hard mode**
- Revealed green letters must stay in position, yellow letters must appear somewhere
- Toggle in settings (disabled once game starts, like NYT)
- Descriptive error messages ("Hard mode: S must be in position 3")
- Share text appends ` *` when hard mode active (NYT convention)

**3. Colorblind / high contrast mode**
- Swaps green → blue (#85c0f9), yellow → orange (#f5793a)
- Applies to tiles, keyboard keys, and emoji share board
- Toggle in settings modal
- ~8% of men are colorblind — this was an accessibility gap

## Why
Market research showed these 3 features are table-stakes that NYT, wordleunlimited (10M/mo), Sanuli (77K/mo), and wordly.org (3M/mo) all have. We were the only major Wordle site missing all three.

## Files changed
- `frontend/src/game.ts` — tutorial logic, hard mode validation, high contrast toggle (+139 lines)
- `frontend/src/style.css` — high contrast color overrides (+19 lines)
- `webapp/templates/game.html` — settings toggles for hard mode + high contrast (+38 lines)

## Test plan
- [ ] First visit (clear localStorage) — tutorial modal should auto-show
- [ ] Second visit — tutorial should NOT show again
- [ ] Enable hard mode in settings before playing
- [ ] Play with hard mode — verify green/yellow constraints enforced
- [ ] Try toggling hard mode mid-game — should be disabled/grayed out
- [ ] Check share text includes ` *` suffix in hard mode
- [ ] Enable high contrast — tiles should be blue/orange instead of green/yellow
- [ ] Verify keyboard keys also change to blue/orange
- [ ] Share emoji grid should use 🟦/🟧 instead of 🟩/🟨 in high contrast
- [ ] Test both light and dark mode with high contrast
- [ ] Build passes, 81 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hard Mode: optional stricter gameplay that validates guesses against revealed hints, blocks invalid submissions, shows warnings, and prevents switching to hard mid-game.
  * Difficulty Selector: choose Easy/Normal/Hard from options modal with related messaging and feedback.
  * High Contrast: accessibility theme with adjusted colors for tiles/keyboard and alternative emoji variants.
  * Preferences & Tutorial: settings persist between visits and a language-aware tutorial shows on first visit; shared results include a hard-mode indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->