### PR TITLE
refactor: slim GA4 to core events, PostHog is primary

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,56 +1,59 @@
 # Wordle Global - TODO
 
-## Retention (Critical - 93% users are new, only 7% return)
+## Retention (IMPROVED - 64% returning users as of Feb 2026)
 
-**Finnish users have 39% return rate vs ~10% for others - study why!**
+**Finnish users have 5.1 sessions/user, Bulgarian 6.9. Overall engagement rate 82%.**
 
 ### Hooked Model Implementation
 
 1. **Trigger** (bring users back daily)
    - [ ] Email/push notifications for daily word reminder
    - [ ] "Yesterday's word was X" teaser on social media
-   - [ ] Browser notifications (already have PWA)
+   - [x] Browser notifications (PWA installed by 1,874 users/mo, 8,932 PWA sessions/mo)
 
 2. **Action** (make playing frictionless)
-   - [ ] Faster load time (already improved: 430KB → 75KB)
+   - [x] Faster load time (430KB → 75KB gzipped)
    - [ ] Remember last played language
-   - [ ] One-tap play from PWA home screen icon
+   - [x] One-tap play from PWA home screen icon
 
 3. **Variable Reward** (make winning satisfying)
-   - [ ] Better win animations (confetti, etc.)
-   - [ ] Share card with emoji grid (improve design)
-   - [ ] Social share preview with user stats and history (win %, streak, guess distribution) to incentivize sharing
+   - [x] Win animations (flip, shake, pop + haptic feedback + sound effects)
+   - [x] Share card with emoji grid
+   - [x] Social share preview with per-language OG images
    - [ ] "Hard mode" for experienced players
-   - [ ] Daily stats comparison with global averages
+   - [x] Daily stats comparison with global averages (community percentile)
 
 4. **Investment** (make users invested)
-   - [ ] Cross-language stats ("You've played 5 languages!")
+   - [x] Cross-language stats ("You've played 5 languages!")
    - [ ] Streak protection (miss a day, keep streak with ad/share)
    - [ ] Achievement badges (first win, 7-day streak, etc.)
    - [ ] Leaderboards per language
 
 ## High Priority
 
-- [ ] Curate word lists for existing languages (50% of user complaints)
-- [ ] Add keyboard layouts for languages missing them
-- [ ] Fully translate game interface (missing: score streaks, options modal)
-- [ ] Migrate homepage (`index.html`) to Vite build (still uses CDN)
+- [x] Curate word lists for existing languages (38 langs now have daily_words.txt)
+- [x] Add keyboard layouts for languages missing them (all 65 have keyboards)
+- [ ] Fully translate game interface (missing: some UI strings in smaller langs)
+- [x] Migrate homepage (`index.html`) to Vite build
 
-## Mobile (58% bounce rate on mobile)
+## Mobile (bounce rate now 21.8% — was 58%)
 
-- [ ] Investigate why mobile users leave quickly
+- [x] Investigate why mobile users leave quickly (fixed: engagement features, PWA, word quality)
 - [ ] Test on low-end Android devices
-- [ ] Reduce time-to-interactive
-- [ ] Consider AMP or lighter mobile version
+- [x] Reduce time-to-interactive (75KB gzipped bundle)
+- [x] AMP not needed — mobile bounce rate dropped from 58% → 22%
 
 ## Features
 
-- [ ] Nice animations for revealing letters
+- [x] Nice animations for revealing letters (flip/shake/pop + haptics + sounds)
 - [ ] 4, 6, 7 letter word variants
-- [ ] Better accent/diacritic handling (French is problematic)
-- [ ] OG image for social sharing
-- [ ] www → non-www redirect
-- [ ] "Unlimited mode" (practice with random words)
+- [x] Better accent/diacritic handling (diacritic normalization maps)
+- [x] OG image for social sharing (per-language + per-share-result images)
+- [x] www → non-www redirect
+- [ ] "Unlimited mode" (practice with random words) — #1 missing feature by traffic potential
+- [ ] Hard mode — table stakes, NYT/Sanuli/wordleunlimited all have it
+- [ ] Colorblind / high contrast mode — accessibility standard
+- [ ] Auto-show tutorial on first visit
 
 ## Language Quality (Priority by Traffic)
 
@@ -101,38 +104,41 @@ The consistent hashing algorithm (for days > 1681/Jan 25, 2026) handles curation
 
 See [CURATED_WORDS.md](./CURATED_WORDS.md) for blocklist registry.
 
-### Arabic (`/ar`) - 13.5K sessions, 56% bounce
+### Arabic (`/ar`) - 10.3K sessions/mo, 22% bounce (was 56%)
 
 - [x] Add Arabic 101 keyboard layout (Arabic 101 + Alphabetical)
-- [ ] Curate word list - remove grammatical forms like حاكما (accusative)
-- [ ] Verify RTL rendering works correctly
+- [x] Char difficulty filter: removed 212 words with rare chars, 1,788 daily words
+- [x] RTL rendering works correctly
+- [ ] Further curate word list — remove grammatical forms
 
-### Hebrew (`/he`) - 3.4K sessions, 61% bounce (worst)
+### Hebrew (`/he`) - 3K sessions/mo, 22% bounce (was 61%) — GROWING +43% WoW
 
 - [x] Add keyboard layouts (PR #105)
-- [ ] Reduce word list from 64K to ~5-10K curated words
+- [x] Reduce word list — suffix dedup + wordfreq filter: 1,000 daily words (100% verified)
+- [x] Blocklist: 1,442 additions
 - [ ] Fix incorrect final letter usage (ושכשכ ends in כ instead of ך)
-- [ ] Remove invalid words: קבותם, ושכשכ (GitHub #79, #72, #77)
+- **Note:** Former dominant competitor (meduyeket.net) is dead. We're likely #1 Hebrew Wordle now.
 
-### Turkish (`/tr`) - 6.6K sessions, 46% bounce
+### Turkish (`/tr`) - 5.6K sessions/mo, 20% bounce (was 46%)
 
 - [x] Add Turkish-Q keyboard layout (Turkish Q + Alphabetical)
 - [ ] Curate to root words only (no suffixed forms)
 - [ ] Use TDK dictionary as source
 
-### Bulgarian (`/bg`) - 4.6K sessions, 54% bounce
+### Bulgarian (`/bg`) - 4.2K sessions/mo, 16% bounce (was 54%) — most loyal users (6.9 sessions/user)
 
 - [x] Keyboard exists (Cyrillic QWERTY)
 - [x] Remove 700+ proper nouns from word list (728 removed, 4952 → 4224 words)
+- [x] Curated schedule: 126 words
 
-### Hungarian (`/hu`) - 2.3K sessions, 55% bounce
+### Hungarian (`/hu`) - 2.9K sessions/mo, 17% bounce (was 55%) — we rank #1 on Google
 
 - [x] Add Hungarian keyboard layout (QWERTZ + Alphabetical)
 - [x] Add missing letter "Y" to character set (GitHub #18)
 - [ ] Remove non-Hungarian words: hodor, rauch, etc.
 - [ ] Fix preverb handling (GitHub #51)
 
-### Croatian (`/hr`) - 5.1K sessions, 48% bounce
+### Croatian (`/hr`) - 6K sessions/mo, 15% bounce (was 48%) — we likely lead this market
 
 - [ ] Major word list cleanup needed (DrWords opened 20+ issues)
 - [ ] Remove Serbian words, proper names, invalid declensions
@@ -147,62 +153,16 @@ See [CURATED_WORDS.md](./CURATED_WORDS.md) for blocklist registry.
 
 ## Analytics & Monitoring
 
-### GA4 Setup (Required)
-- [ ] Register `language` as custom dimension in GA4 Admin (currently sent but not queryable)
-- [ ] Register `attempt_number` as custom dimension
-- [ ] Register `won` as custom dimension
-
-### GA4 Bug Fix (High Priority)
+### GA4 Setup
 - [x] Fix gtag initialization timing in `_base_head.html`
-  - Moved `gtag('js')` and `gtag('config')` outside the `window.load` listener so early events (game_start, pwa_session) queue properly before gtag.js loads.
-
-### Analytics Refactor (v2)
-
-Current implementation fires fragmented events. Refactor to session-aggregated approach:
-
-**Problems with current schema:**
-1. `frustration_signal` fires every 3rd consecutive invalid - noisy. 247 signals in realtime doesn't tell us if it's 247 users or 30 users hitting it 8x each
-2. Module-level state (`consecutiveInvalidCount`) is fragile - doesn't reset on game completion
-3. `game_complete` missing struggle context (total invalids, max streak, time spent)
-
-**Fix:** Track session state in `game.ts`, pass full picture to `game_complete`:
-
-```typescript
-// In game.ts during gameplay:
-let sessionInvalidCount = 0;
-let maxConsecutiveInvalid = 0;
-let currentConsecutiveInvalid = 0;
-
-// On invalid word:
-sessionInvalidCount++;
-currentConsecutiveInvalid++;
-maxConsecutiveInvalid = Math.max(maxConsecutiveInvalid, currentConsecutiveInvalid);
-
-// On valid word:
-currentConsecutiveInvalid = 0;  // Reset streak
-
-// On game complete - ONE event with full context:
-analytics.trackGameComplete({
-    language,
-    won,
-    attempts,
-    streak_after,
-    total_invalid_attempts: sessionInvalidCount,
-    max_consecutive_invalid: maxConsecutiveInvalid,
-    had_frustration: maxConsecutiveInvalid >= 3,
-    time_to_complete_seconds: Math.floor((Date.now() - gameStartTime) / 1000),
-});
-```
-
-Then delete `frustration_signal` event entirely. One event with full context > many fragmented signals.
-
-- [ ] Refactor analytics to session-aggregated model
-- [ ] Add time tracking (game start → complete)
-- [ ] Delete `frustration_signal` event, move to `game_complete` property
-- [ ] Track completion rate per language
+- [x] Refactored analytics to session-aggregated model
+- [x] `game_complete` now includes: total_invalid_attempts, max_consecutive_invalid, had_frustration, time_to_complete_seconds
+- [x] `frustration_signal` replaced with frustration state in game_complete
+- [x] Time tracking (game start → complete)
+- [ ] Register custom dimensions in GA4 Admin for better querying
 - [ ] A/B test retention features
 - [ ] Monitor Core Web Vitals
-- [ ] Error tracking (Sentry or similar)
+- [ ] Error tracking (Sentry or similar) — currently 4,623 page_error events/mo
 
 ## Architecture
 
@@ -213,18 +173,32 @@ See [CURATED_WORDS.md](./CURATED_WORDS.md) for curated language registry and blo
 - [ ] Add `/api/language/{code}` JSON endpoint
 - [ ] Add `/api/languages` list endpoint
 - [ ] Refactor game to fetch data from API instead of Jinja injection
-- [ ] Move keyboard rendering to JavaScript
+- [x] Move keyboard rendering to JavaScript
 - [ ] Consolidate storage to localStorage only (remove cookies)
 - [ ] Update service worker to cache API responses
 - [ ] Enable offline play for all visited languages
+
+## SEO (added Mar 2026)
+
+- [x] hreflang tags for all 65 languages + x-default
+- [x] JSON-LD structured data (WebSite, WebApplication, BreadcrumbList, CollectionPage)
+- [x] Dynamic sitemaps (index + main + 65 per-language word sitemaps)
+- [x] Per-language meta titles and descriptions (localized)
+- [x] OG images (default + per-language + per-share-result)
+- [x] Canonical URLs on all pages
+- [x] noscript content block on game pages (localized how-to-play + cross-language links)
+- [ ] FAQ / SEO content pages (wordleunlimited has this, drives 10M/mo)
+- [ ] Get listed on Wordle alternative roundup sites
+- [ ] Add Article schema to word pages
 
 ## Testing Improvements
 
 Current test coverage:
 
-- **pytest**: Word list validation, language configs, daily word algorithm (1636 tests)
-- **Vitest**: `calculateColors`, `calculateStats`, diacritics, positional normalization
+- **pytest**: Word list validation, language configs, daily word algorithm (2029 passed, 289 skipped, 4 xfailed)
+- **Vitest**: 81 tests — calculateColors, calculateStats, diacritics, positional normalization, definitions
 - **Playwright**: 18 smoke tests (homepage, game pages, RTL, dark mode, mobile) - **local only, not in CI**
+- **CI**: GitHub Actions runs lint (Ruff), pytest, vitest, type-check, and build on every PR
 
 ### CI Improvements
 
@@ -259,14 +233,15 @@ Priority order for daily word selection (days > 1681):
 
 ### Curated Schedules Needed
 
-Priority languages (by traffic/bounce rate):
+Priority languages (by traffic, updated Mar 2026):
 
-- [ ] Arabic (ar) - 13.5K sessions, needs native speaker review
-- [ ] Turkish (tr) - 6.6K sessions, needs native speaker review
-- [ ] Croatian (hr) - 5.1K sessions, major cleanup needed
-- [ ] Hebrew (he) - 3.4K sessions, needs final form filtering
-- [ ] Hungarian (hu) - 2.3K sessions, needs non-Hungarian word removal
-- [ ] Serbian (sr) - Has blocklist but needs curated schedule
+- [ ] Arabic (ar) - 10.3K sessions/mo, needs native speaker review
+- [ ] Turkish (tr) - 5.6K sessions/mo, needs native speaker review
+- [ ] Croatian (hr) - 6K sessions/mo, major cleanup needed
+- [ ] Hebrew (he) - 3K sessions/mo (+43% growth), has daily_words but needs final form filtering
+- [ ] Hungarian (hu) - 2.9K sessions/mo, needs non-Hungarian word removal
+- [ ] Serbian (sr) - 1.9K sessions/mo, has blocklist but needs curated schedule
+- [ ] English (en) - 45K sessions/mo, no daily_words.txt yet (uses main list)
 
 ## Completed
 


### PR DESCRIPTION
## Summary
- GA4 now only receives 4 events: `game_start`, `game_complete`, `game_abandon`, `page_view_enhanced`
- All other 15+ events are PostHog-only
- GA4 was silently dropping 6/10 properties on `game_complete` because they weren't registered as custom dimensions — no point sending data it ignores

## Why
PostHog captures every property on every event automatically. GA4 requires manual registration of each custom dimension and silently drops unregistered ones. We confirmed today that `game_mode`, `had_frustration`, `total_invalid_attempts`, `max_consecutive_invalid`, `streak_after`, and `time_to_complete_seconds` were all being silently dropped by GA4.

GA4 remains for: Google Search Console integration, free session counting, and basic game metrics.

## Change
One-line change in `track()` — GA4 send is now gated by a `GA4_EVENTS` allowlist.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 81 tests pass
- [ ] Verify GA4 Realtime still shows `game_complete` events
- [ ] Verify PostHog still receives all events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO enhancements including dynamic sitemaps and per-language metadata for improved discoverability.
  * Expanded analytics capabilities with session tracking and frustration signal monitoring.

* **Bug Fixes**
  * Improved mobile bounce rate and time-to-interactive performance.
  * Enhanced keyboard and diacritic handling for better user experience.

* **Documentation**
  * Updated progress tracking with current engagement metrics and language-specific performance data.
  * Documented completed infrastructure improvements including PWA support and build optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->