### PR TITLE
feat: capture rejected words in invalid_word events

### DIFF
--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -116,7 +116,7 @@ interface ShareParams {
 interface InvalidWordParams {
     language: string;
     attempt_number: number;
-    // Note: We intentionally don't track the actual word for privacy
+    word: string;
 }
 
 interface SettingsChangeParams {
@@ -520,7 +520,7 @@ export const trackInvalidWord = (params: InvalidWordParams): void => {
     track('invalid_word', {
         language: params.language,
         attempt_number: params.attempt_number,
-        // We don't track the actual word for privacy
+        word: params.word,
     });
 };
 

--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -869,6 +869,7 @@ export const createGameApp = () => {
                         analytics.trackInvalidWordAndUpdateState({
                             language: this.config?.language_code || 'unknown',
                             attempt_number: this.active_row + 1,
+                            word: typedWord,
                         });
                         analytics.trackGuessSubmit(
                             this.config?.language_code || 'unknown',


### PR DESCRIPTION
## Summary
- Adds the actual typed word to `invalid_word` PostHog events
- Enables querying "top rejected words by language" to improve word lists

## Why
PostHog data from today shows English has 9.3 invalid attempts per game — users try words that should be valid but aren't in our lists. Without knowing *which* words they tried, we can't fix it.

## Change
- `InvalidWordParams` interface: add `word: string`
- `trackInvalidWord()`: send `word` property
- `game.ts`: pass `typedWord` at call site

## Usage
Once deployed, query in PostHog:
```sql
SELECT word, language, count() as times_rejected, uniq(distinct_id) as unique_users
FROM events WHERE event = 'invalid_word'
GROUP BY word, language ORDER BY times_rejected DESC
```

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] `pnpm test` — 81 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics Improvements**
  * Enhanced invalid word tracking with additional data collection to improve analytics accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->