### PR TITLE
fix: infinite recursion in getReferrer() crashing all pages

### DIFF
--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -171,7 +171,7 @@ const track = (eventName: string, params?: Record<string, unknown>): void => {
 /**
  * Get referrer or 'direct'
  */
-const getReferrer = (): string => getReferrer();
+const getReferrer = (): string => document.referrer || 'direct';
 
 /**
  * Get platform type for PWA tracking


### PR DESCRIPTION
## URGENT

`getReferrer()` in analytics.ts calls itself instead of `document.referrer`, causing `RangeError: Maximum call stack size exceeded`. This crashes the Vue app on ALL pages — the homepage shows no languages, game pages don't load.

## Fix
```diff
-const getReferrer = (): string => getReferrer();
+const getReferrer = (): string => document.referrer || 'direct';
```

Introduced in PR #159 (slim GA4 refactor) — the `replace_all` edit that replaced `document.referrer || 'direct'` with `getReferrer()` also caught the function definition itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where analytics referrer tracking was causing crashes. Referrer data is now properly captured for analytics functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->