### PR TITLE
fix: deduplicate definition_view events on page revisits

### DIFF
--- a/frontend/src/game.ts
+++ b/frontend/src/game.ts
@@ -241,6 +241,7 @@ interface GameData {
     communityIsTopScore: boolean;
     communityTotal: number;
     communityStatsLink: string | null;
+    definitionTracked: boolean;
     hardMode: boolean;
     highContrast: boolean;
     difficultyShake: boolean;
@@ -444,6 +445,7 @@ export const createGameApp = () => {
                 communityIsTopScore: false,
                 communityTotal: 0,
                 communityStatsLink: null,
+                definitionTracked: false,
             };
         },
 
@@ -1768,7 +1770,11 @@ export const createGameApp = () => {
                                     },
                                     wordPageUrl
                                 );
-                                analytics.trackDefinitionView(langCode, def.source);
+                                // Only track on fresh game completion, not page revisits
+                                if (!this.definitionTracked) {
+                                    analytics.trackDefinitionView(langCode, def.source);
+                                    this.definitionTracked = true;
+                                }
                             })
                             .catch(() => {
                                 container.style.display = 'none';


### PR DESCRIPTION
## Summary
`definition_view` was firing every time `loadDefinition()` ran — including when users revisited an already-completed game page. This inflated the count to ~150% of game completions.

## Fix
Add `definitionTracked` flag to Vue data. Only fire `definition_view` once per game session.

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] `pnpm test` — 81 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed analytics tracking for definition views to only record once per game session, preventing duplicate counts on revisits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->