### PR TITLE
fix: use $pageview event for PostHog web analytics

### DIFF
--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -55,7 +55,7 @@ import posthog from './posthog';
 // GA4 only tracks these core events (with registered custom dimensions: language, won, attempts).
 // Everything else is PostHog-only. GA4 silently drops unregistered dimensions, so there's no
 // point sending rich events to it.
-const GA4_EVENTS = new Set(['game_start', 'game_complete', 'game_abandon', 'page_view_enhanced']);
+const GA4_EVENTS = new Set(['game_start', 'game_complete', 'game_abandon', '$pageview']);
 
 // Events excluded from PostHog to stay within free tier (1M events/month).
 // These high-volume events (fired per-guess) are still tracked in GA4 where there is no cap.
@@ -145,7 +145,7 @@ interface ErrorParams {
 
 /**
  * Safe dual-send wrapper.
- * GA4: only core events (game_start, game_complete, game_abandon, page_view_enhanced).
+ * GA4: only core events (game_start, game_complete, game_abandon, $pageview).
  * PostHog: everything except high-volume per-guess events.
  */
 const track = (eventName: string, params?: Record<string, unknown>): void => {
@@ -727,7 +727,7 @@ export const trackReferralLanding = (language: string, referralParam: string): v
  * Call once on page load to capture session context
  */
 export const trackPageView = (language: string): void => {
-    track('page_view_enhanced', {
+    track('$pageview', {
         language,
         is_pwa: isStandalone(),
         platform: getPlatform(),

--- a/frontend/src/posthog.ts
+++ b/frontend/src/posthog.ts
@@ -4,7 +4,7 @@ posthog.init('phc_DMY07B83ghetzxgIbBhobbdSjlueym6vNVVZwM79SPp', {
     api_host: 'https://eu.i.posthog.com',
     defaults: '2026-01-30',
     autocapture: false,
-    capture_pageview: false, // We track pageviews via trackPageView/trackHomepageView
+    capture_pageview: false,
     capture_pageleave: true,
     disable_session_recording: false,
     session_recording: {


### PR DESCRIPTION
## Summary
- Renames `page_view_enhanced` → `$pageview` so PostHog's built-in web analytics (DAU, WAU, bounce rate) works
- Keeps `capture_pageview: false` — we send `$pageview` manually to attach custom properties (language, platform, referrer, is_pwa)
- No change in event volume

## Test plan
- [ ] Verify PostHog Web Analytics dashboard shows DAU/WAU after deploy
- [ ] Verify GA4 still receives pageview events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal event tracking identifiers and cleaned up analytics configuration code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->