### PR TITLE
fix: wire up definition/image in stats modal + rotating globe

### DIFF
--- a/components/game/StatsModal.vue
+++ b/components/game/StatsModal.vue
@@ -68,11 +68,75 @@
                 </a>
             </div>
 
-            <!-- Definition Card (shown after game completion) -->
-            <div id="definition-card" class="px-6 pb-2" style="display: none" />
+            <!-- Definition Card -->
+            <div v-if="game.todayDefinitionLoading" class="px-6 pb-2">
+                <div class="animate-pulse flex gap-2">
+                    <div class="flex-1 space-y-1.5">
+                        <div class="h-3 bg-neutral-200 dark:bg-neutral-700 rounded w-20" />
+                        <div class="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-full" />
+                    </div>
+                </div>
+            </div>
+            <div v-else-if="game.todayDefinition" class="px-6 pb-2">
+                <div class="flex items-start gap-2">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2 mb-0.5">
+                            <span
+                                class="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
+                            >
+                                {{ lang.config?.ui?.definition || 'Definition' }}
+                            </span>
+                            <span
+                                v-if="game.todayDefinition.partOfSpeech"
+                                class="text-xs text-neutral-400 dark:text-neutral-500 italic"
+                            >
+                                {{ game.todayDefinition.partOfSpeech }}
+                            </span>
+                        </div>
+                        <p class="text-sm text-neutral-800 dark:text-neutral-200">
+                            <strong class="uppercase">{{ game.todayDefinition.word }}</strong>
+                            &mdash; {{ game.todayDefinition.definition }}
+                        </p>
+                    </div>
+                    <a
+                        v-if="game.todayDefinition.url"
+                        :href="game.todayDefinition.url"
+                        class="flex-shrink-0 text-neutral-400 hover:text-blue-500 dark:text-neutral-500 dark:hover:text-blue-400"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-4 w-4"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                        >
+                            <path
+                                d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"
+                            />
+                            <path
+                                d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"
+                            />
+                        </svg>
+                    </a>
+                </div>
+            </div>
 
-            <!-- Word Art Image (shown after game completion, if enabled) -->
-            <div id="word-image-card" class="px-6 pt-1 pb-2" style="display: none" />
+            <!-- Word Art Image -->
+            <div v-if="game.todayImageLoading" class="px-6 pt-1 pb-2">
+                <div class="animate-pulse">
+                    <div class="h-48 bg-neutral-200 dark:bg-neutral-700 rounded-lg w-full" />
+                </div>
+            </div>
+            <div v-else-if="game.todayImageUrl" class="px-6 pt-1 pb-2">
+                <a
+                    :href="'/' + lang.languageCode + '/word/' + lang.todaysIdx"
+                >
+                    <img
+                        :src="game.todayImageUrl"
+                        :alt="lang.todaysWord"
+                        class="w-full max-h-48 object-contain rounded-lg"
+                    />
+                </a>
+            </div>
 
             <!-- Percentile + Share -->
             <div class="px-6 py-3 border-t border-gray-200 dark:border-gray-600">

--- a/components/game/StatsModal.vue
+++ b/components/game/StatsModal.vue
@@ -127,9 +127,7 @@
                 </div>
             </div>
             <div v-else-if="game.todayImageUrl" class="px-6 pt-1 pb-2">
-                <a
-                    :href="'/' + lang.languageCode + '/word/' + lang.todaysIdx"
-                >
+                <a :href="'/' + lang.languageCode + '/word/' + lang.todaysIdx">
                     <img
                         :src="game.todayImageUrl"
                         :alt="lang.todaysWord"

--- a/components/game/StatsModal.vue
+++ b/components/game/StatsModal.vue
@@ -419,6 +419,7 @@ defineEmits<{
 const game = useGameStore();
 const statsStore = useStatsStore();
 const lang = useLanguageStore();
+const settings = useSettingsStore();
 
 // ---------------------------------------------------------------------------
 // Local state

--- a/components/game/StatsModal.vue
+++ b/components/game/StatsModal.vue
@@ -68,8 +68,8 @@
                 </a>
             </div>
 
-            <!-- Definition Card -->
-            <div v-if="game.todayDefinitionLoading" class="px-6 pb-2">
+            <!-- Definition Card (respects Word Info toggle) -->
+            <div v-if="settings.wordInfoEnabled && game.todayDefinitionLoading" class="px-6 pb-2">
                 <div class="animate-pulse flex gap-2">
                     <div class="flex-1 space-y-1.5">
                         <div class="h-3 bg-neutral-200 dark:bg-neutral-700 rounded w-20" />
@@ -77,7 +77,7 @@
                     </div>
                 </div>
             </div>
-            <div v-else-if="game.todayDefinition" class="px-6 pb-2">
+            <div v-else-if="settings.wordInfoEnabled && game.todayDefinition" class="px-6 pb-2">
                 <div class="flex items-start gap-2">
                     <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2 mb-0.5">
@@ -101,6 +101,7 @@
                     <a
                         v-if="game.todayDefinition.url"
                         :href="game.todayDefinition.url"
+                        aria-label="View word details"
                         class="flex-shrink-0 text-neutral-400 hover:text-blue-500 dark:text-neutral-500 dark:hover:text-blue-400"
                     >
                         <svg
@@ -120,13 +121,13 @@
                 </div>
             </div>
 
-            <!-- Word Art Image -->
-            <div v-if="game.todayImageLoading" class="px-6 pt-1 pb-2">
+            <!-- Word Art Image (respects Word Info toggle) -->
+            <div v-if="settings.wordInfoEnabled && game.todayImageLoading" class="px-6 pt-1 pb-2">
                 <div class="animate-pulse">
                     <div class="h-48 bg-neutral-200 dark:bg-neutral-700 rounded-lg w-full" />
                 </div>
             </div>
-            <div v-else-if="game.todayImageUrl" class="px-6 pt-1 pb-2">
+            <div v-else-if="settings.wordInfoEnabled && game.todayImageUrl" class="px-6 pt-1 pb-2">
                 <a :href="'/' + lang.languageCode + '/word/' + lang.todaysIdx">
                     <img
                         :src="game.todayImageUrl"

--- a/scripts/globe_designs/generate_globe.py
+++ b/scripts/globe_designs/generate_globe.py
@@ -34,7 +34,7 @@ def build_land_grid(coastlines, resolution=720):
             if len(pts) >= 3:
                 draw.polygon(pts, fill=255)
     # Crop the center strip
-    grid_arr = np.array(grid_img)[:, w:w*2]
+    grid_arr = np.array(grid_img)[:, w : w * 2]
     return grid_arr > 128, w, h
 
 
@@ -97,8 +97,9 @@ def render_shaded(rotation_deg, land_grid, grid_w, grid_h):
     spec = spec.filter(ImageFilter.GaussianBlur(18))
     mask = Image.new("L", (RENDER_SIZE, RENDER_SIZE), 0)
     R = int(RADIUS)
-    ImageDraw.Draw(mask).ellipse([int(CX)-R, int(CY)-R, int(CX)+R, int(CY)+R], fill=255)
+    ImageDraw.Draw(mask).ellipse([int(CX) - R, int(CY) - R, int(CX) + R, int(CY) + R], fill=255)
     from PIL import ImageChops
+
     spec.putalpha(ImageChops.multiply(spec.split()[3], mask))
     img = Image.alpha_composite(img, spec)
 
@@ -117,7 +118,7 @@ def main():
     for shape in sf.shapes():
         parts = list(shape.parts) + [len(shape.points)]
         for i in range(len(parts) - 1):
-            ring = shape.points[parts[i]:parts[i + 1]]
+            ring = shape.points[parts[i] : parts[i + 1]]
             coastlines.append([(pt[1], pt[0]) for pt in ring])
     print(f"  {len(coastlines)} polygons")
 
@@ -130,14 +131,17 @@ def main():
         angle = (360.0 / FRAMES) * i
         frame = render_shaded(angle, land_grid, gw, gh)
         frames.append(frame)
-        print(f"  {i+1}/{FRAMES}")
+        print(f"  {i + 1}/{FRAMES}")
 
     # Save APNG — 350ms per frame = slow, gentle rotation
     delay = 350
     frames[0].save(
         out / "globe_v3.apng",
-        save_all=True, append_images=frames[1:],
-        duration=delay, loop=0, disposal=2,
+        save_all=True,
+        append_images=frames[1:],
+        duration=delay,
+        loop=0,
+        disposal=2,
     )
     frames[0].save(out / "globe_v3_f0.png")
     frames[4].save(out / "globe_v3_f4.png")

--- a/stores/game.ts
+++ b/stores/game.ts
@@ -128,6 +128,17 @@ export const useGameStore = defineStore('game', () => {
 
     const shareButtonState = ref<'idle' | 'success'>('idle');
 
+    // Definition & word image for stats modal display
+    const todayDefinition = ref<{
+        word: string;
+        definition: string;
+        partOfSpeech?: string;
+        url?: string;
+    } | null>(null);
+    const todayImageUrl = ref<string | null>(null);
+    const todayImageLoading = ref(false);
+    const todayDefinitionLoading = ref(false);
+
     const allowAnyWord = ref(false);
 
     const maxDifficultyUsed = ref(0);
@@ -674,13 +685,9 @@ export const useGameStore = defineStore('game', () => {
             }, 2500);
         }
 
-        // Load definition for stats modal display
+        // Load definition and image for stats modal display
         if (import.meta.client) {
-            const { fetchDefinition } = useDefinitions();
-            fetchDefinition(lang.todaysWord, lang.languageCode).then((def) => {
-                // Store definition for stats modal to display
-                // For now, just mark that we tried to load it
-            });
+            loadDefinitionAndImage(lang.todaysWord, lang.languageCode, lang.todaysIdx);
         }
 
         submitWordStats(true, activeRow.value);
@@ -736,13 +743,9 @@ export const useGameStore = defineStore('game', () => {
         gameWon.value = false;
         attempts.value = 'X';
 
-        // Load definition for stats modal display
+        // Load definition and image for stats modal display
         if (import.meta.client) {
-            const { fetchDefinition } = useDefinitions();
-            fetchDefinition(lang.todaysWord, lang.languageCode).then((def) => {
-                // Store definition for stats modal to display
-                // For now, just mark that we tried to load it
-            });
+            loadDefinitionAndImage(lang.todaysWord, lang.languageCode, lang.todaysIdx);
         }
 
         submitWordStats(false, activeRow.value);
@@ -920,6 +923,11 @@ export const useGameStore = defineStore('game', () => {
                         })
                     );
                 }
+
+                // Load definition/image if game was already completed
+                if (data.game_over) {
+                    loadDefinitionAndImage(lang.todaysWord, lang.languageCode, lang.todaysIdx);
+                }
             }
         } catch {
             // localStorage unavailable or corrupted data
@@ -1049,6 +1057,44 @@ export const useGameStore = defineStore('game', () => {
         } catch {
             // Ignore errors
         }
+    }
+
+    // ---- Definition & Image for Stats Modal ----
+
+    function loadDefinitionAndImage(word: string, langCode: string, dayIdx: number): void {
+        const settings = useSettingsStore();
+        if (!settings.wordInfoEnabled) return;
+
+        todayDefinitionLoading.value = true;
+        todayImageLoading.value = true;
+
+        const { fetchDefinition } = useDefinitions();
+        fetchDefinition(word, langCode)
+            .then((def) => {
+                if (def.definition) {
+                    todayDefinition.value = {
+                        word: def.word,
+                        definition: def.definition,
+                        partOfSpeech: def.partOfSpeech,
+                        url: `/${langCode}/word/${dayIdx}`,
+                    };
+                }
+            })
+            .finally(() => {
+                todayDefinitionLoading.value = false;
+            });
+
+        // Load word image
+        const imgUrl = `/api/${langCode}/word-image/${encodeURIComponent(word)}?day_idx=${dayIdx}`;
+        const img = new Image();
+        img.onload = () => {
+            todayImageUrl.value = imgUrl;
+            todayImageLoading.value = false;
+        };
+        img.onerror = () => {
+            todayImageLoading.value = false;
+        };
+        img.src = imgUrl;
     }
 
     // ---- Share ----
@@ -1207,6 +1253,10 @@ export const useGameStore = defineStore('game', () => {
         communityTotal,
         communityStatsLink,
         shareButtonState,
+        todayDefinition,
+        todayImageUrl,
+        todayImageLoading,
+        todayDefinitionLoading,
         allowAnyWord,
         maxDifficultyUsed,
         // hardMode is owned by settings store

--- a/stores/game.ts
+++ b/stores/game.ts
@@ -1062,9 +1062,7 @@ export const useGameStore = defineStore('game', () => {
     // ---- Definition & Image for Stats Modal ----
 
     function loadDefinitionAndImage(word: string, langCode: string, dayIdx: number): void {
-        const settings = useSettingsStore();
-        if (!settings.wordInfoEnabled) return;
-
+        // Always load — template controls visibility via settings.wordInfoEnabled
         todayDefinitionLoading.value = true;
         todayImageLoading.value = true;
 


### PR DESCRIPTION
## Summary

The Nuxt migration left the definition card and word art image as empty hidden divs in the stats modal. The Flask version populated these via DOM manipulation (`renderDefinitionCard`, `renderWordImage`). This PR replaces them with reactive Vue rendering.

**What was broken**: After winning/losing a game, no definition or AI word art was shown in the stats modal — just the word and share button.

**Fix**:
- Add `todayDefinition` / `todayImageUrl` state to game store
- Fetch definition via API and preload image on game completion
- Also load on page reload when game already completed (localStorage restore)
- Show loading skeletons while fetching
- Link to word detail page
- Respect `wordInfoEnabled` setting (Word Info toggle in settings)

## Test plan
- [x] 138/138 vitest tests pass
- [ ] Play a game → win → stats modal shows definition + image
- [ ] Reload page after winning → reopen stats modal → definition + image still show
- [ ] Disable Word Info in settings → no definition/image shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Definition and image display in stats modal with loading states when game completes
  * Globe image added to header branding

* **Style**
  * Language improvement banner redesigned with updated colors and refined dismiss button styling
  * Improved visual hierarchy and usability across banners and headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->