### PR TITLE
fix: dynamic OG image for share links (?r= param)

### DIFF
--- a/pages/[lang]/index.vue
+++ b/pages/[lang]/index.vue
@@ -88,6 +88,29 @@ let seoDescription = isUntranslatedDesc
     : `${nativeDesc} | Wordle ${config.name}`;
 if (seoDescription.length > 160) seoDescription = nativeDesc.substring(0, 155) + '...';
 
+// Share result param (?r=1-6 or ?r=x) — used for social preview when sharing
+const shareResult = route.query.r as string | undefined;
+const validResults = ['1', '2', '3', '4', '5', '6', 'x'];
+const isShareLink = shareResult !== undefined && validResults.includes(shareResult);
+
+// Dynamic share image: use result-specific image for share links, default to _1 otherwise
+const shareImageSuffix = isShareLink ? shareResult : '1';
+const shareImageUrl = `https://wordle.global/images/share/${lang}_${shareImageSuffix}.png`;
+
+// Override title/description for share links (matches Flask behavior)
+const configText = gameData.value.config.text || {};
+if (isShareLink) {
+    if (shareResult === 'x') {
+        seoTitle = `${wordleBase} — X/6`;
+        seoDescription = configText.share_challenge_lose || "I didn't get today's Wordle. Can you?";
+    } else {
+        seoTitle = `${wordleBase} — ${shareResult}/6`;
+        const challengeWin =
+            configText.share_challenge_win || "I got today's Wordle in {n}. Can you beat me?";
+        seoDescription = challengeWin.replace('{n}', shareResult!);
+    }
+}
+
 useSeoMeta({
     title: seoTitle,
     description: seoDescription,
@@ -96,7 +119,7 @@ useSeoMeta({
     ogUrl: `https://wordle.global/${lang}`,
     ogType: 'website',
     ogLocale: config.meta?.locale || lang,
-    ogImage: `https://wordle.global/images/share/${lang}_1.png`,
+    ogImage: shareImageUrl,
     ogImageWidth: 1200,
     ogImageHeight: 630,
     twitterCard: 'summary_large_image',


### PR DESCRIPTION
## Summary
- When sharing via `?r=4`, the OG image was always showing `en_1.png` (1/6 score) instead of `en_4.png` (4/6)
- Now reads the `?r=` query param on SSR and selects the correct share image + overrides title/description
- `?r=4` → image shows 4/6, title says "Wordle English — 4/6", description shows localized challenge text
- `?r=x` → image shows X/6, title says "Wordle English — X/6", description shows loss challenge text
- No `?r=` → defaults to `_1.png` (normal page visit, not a share link)

Fixes the regression from Flask where this was handled server-side in the route handler.

## Test plan
- [ ] Share a game result and paste link in Discord/WhatsApp/Telegram — verify preview matches score
- [ ] Test `?r=1` through `?r=6` and `?r=x` — each should show correct image
- [ ] Test no `?r=` param — should show default `_1.png`
- [ ] Test non-English: `/de?r=3` should show German challenge text