### PR TITLE
fix: stats page NaN in total words, sort languages alphabetically

### DIFF
--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -579,7 +579,7 @@ function myDistPct(n: number): string {
                                                 {{ lang.name_native }}
                                             </span>
                                             <span
-                                                v-if="lang.has_schedule"
+                                                v-if="lang.n_daily > 0"
                                                 class="ml-1 text-[9px] bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 px-1 rounded"
                                             >
                                                 curated
@@ -599,9 +599,7 @@ function myDistPct(n: number): string {
                                         <td
                                             class="py-1.5 px-2 text-right tabular-nums text-neutral-500 dark:text-neutral-400"
                                         >
-                                            {{
-                                                (lang.n_words + lang.n_supplement).toLocaleString()
-                                            }}
+                                            {{ lang.n_words.toLocaleString() }}
                                         </td>
                                         <td
                                             v-if="stats.global_plays > 0"

--- a/server/api/stats.get.ts
+++ b/server/api/stats.get.ts
@@ -64,7 +64,7 @@ export default defineEventHandler(() => {
         });
     }
 
-    langStats.sort((a, b) => b.n_words - a.n_words);
+    langStats.sort((a, b) => a.name.localeCompare(b.name));
 
     const globalPlays = langStats.reduce((sum, ls) => sum + ls.total_plays, 0);
     const globalWins = langStats.reduce((sum, ls) => sum + ls.total_wins, 0);


### PR DESCRIPTION
## Summary
- **NaN fix**: Template referenced `lang.n_supplement` which doesn't exist in the API response, causing `n_words + undefined = NaN` for every language row
- **Sort fix**: Languages now sorted alphabetically by name instead of by word count
- **Badge fix**: "curated" badge checked non-existent `has_schedule` field, now uses `n_daily > 0`

## Test plan
- [ ] Visit /stats — Total Words column should show numbers, not NaN
- [ ] Languages should be in alphabetical order (Arabic, Azerbaijani, Bengali...)
- [ ] "curated" badge should appear next to languages with daily word pools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated criteria for displaying the "curated" badge in the All Languages table
  * Modified the Total Words calculation in statistics displays
  * Language list now sorted alphabetically instead of by word count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->