### PR TITLE
fix: hard mode treats diacritics as equivalent

### DIFF
--- a/stores/game.ts
+++ b/stores/game.ts
@@ -17,7 +17,12 @@ import { defineStore } from 'pinia';
 import { useLanguageStore } from '~/stores/language';
 import { useSettingsStore } from '~/stores/settings';
 import { useStatsStore } from '~/stores/stats';
-import { buildNormalizedWordMap, normalizeWord } from '~/utils/diacritics';
+import {
+    buildNormalizedWordMap,
+    charsMatch,
+    normalizeChar,
+    normalizeWord,
+} from '~/utils/diacritics';
 import { toFinalForm, toRegularForm } from '~/utils/positional';
 import { splitWord } from '~/utils/graphemes';
 import { calculateCommunityPercentile } from '~/utils/stats';
@@ -967,6 +972,9 @@ export const useGameStore = defineStore('game', () => {
      * Returns an error message if invalid, or null if valid.
      */
     function checkHardMode(guess: string): string | null {
+        const lang = useLanguageStore();
+        const nMap = lang.normalizeMap;
+
         for (let r = 0; r < activeRow.value; r++) {
             const row = tiles.value[r];
             const colors = tileColors.value[r];
@@ -978,11 +986,15 @@ export const useGameStore = defineStore('game', () => {
                 if (!letter) continue;
 
                 if (color === 'correct') {
-                    if (guess[c]?.toLowerCase() !== letter.toLowerCase()) {
+                    if (!charsMatch(guess[c] || '', letter, nMap)) {
                         return `Hard mode: ${letter.toUpperCase()} must be in position ${c + 1}`;
                     }
                 } else if (color === 'semicorrect') {
-                    if (!guess.toLowerCase().includes(letter.toLowerCase())) {
+                    const normalizedLetter = normalizeChar(letter, nMap).toLowerCase();
+                    const guessHasLetter = [...guess].some(
+                        (g) => normalizeChar(g, nMap).toLowerCase() === normalizedLetter
+                    );
+                    if (!guessHasLetter) {
                         return `Hard mode: guess must contain ${letter.toUpperCase()}`;
                     }
                 }


### PR DESCRIPTION
## Summary
Hard mode was rejecting valid guesses when diacritics were involved. For example, in Portuguese, if `Ã` was green in position 4, submitting `BARÃO` would fail with "Hard mode: Ã must be in position 4" because `ã !== a` in a literal comparison.

Now uses the language's `diacritic_map` via `charsMatch()` and `normalizeChar()` — the same normalization the color algorithm already uses — so diacritically equivalent characters are treated as matching.

**Affected languages**: Portuguese, Spanish, French, German, and any language with a `diacritic_map` in its config.

## Test plan
- [ ] Play Portuguese in hard mode — get `Ã` green, then submit a word with `A` in that position → should be accepted
- [ ] Play French in hard mode — get `É` yellow, submit word with `E` → should be accepted
- [ ] Languages without diacritic_map (Finnish, Swedish, etc.) are unaffected — their accented chars are distinct letters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hard-mode validation now correctly handles accented and special characters across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->