### PR TITLE
fix: touchend.prevent blocked all key taps after diacritic popup

### DIFF
--- a/components/game/KeyboardKey.vue
+++ b/components/game/KeyboardKey.vue
@@ -8,7 +8,7 @@
         @click="handleClick"
         @touchstart.passive="handleTouchStart"
         @touchmove.passive="handleTouchMove"
-        @touchend.prevent="handleTouchEnd"
+        @touchend="handleTouchEnd"
         @touchcancel="handleTouchCancel"
         @mousedown="handleMouseDown"
         @contextmenu="variants?.length ? $event.preventDefault() : undefined"
@@ -148,7 +148,7 @@ function handleTouchMove(e: TouchEvent) {
     updateActiveVariant(touch.clientX);
 }
 
-function handleTouchEnd() {
+function handleTouchEnd(e: TouchEvent) {
     if (!props.variants?.length) {
         touchActive = false;
         return;
@@ -158,6 +158,7 @@ function handleTouchEnd() {
     touchActive = false;
 
     if (popupVisible.value) {
+        e.preventDefault(); // Only prevent click when popup was used
         selectAndDismiss();
     }
 }


### PR DESCRIPTION
## Problem

After using the diacritic long-press popup on mobile, ALL subsequent key taps stopped working — even on different pages. The keyboard became completely unresponsive.

## Root Cause

`@touchend.prevent` on `KeyboardKey.vue` unconditionally called `preventDefault()` on every key's touchend event. This prevented the browser from generating the subsequent `click` event. Since `handleClick` is where key presses are emitted, no letters could be typed after any touch interaction.

## Fix

Changed `@touchend.prevent="handleTouchEnd"` to `@touchend="handleTouchEnd"` and moved `e.preventDefault()` inside the handler, only calling it when the popup was actually shown and used. Normal key taps now complete the full touch→click cycle.

## Test plan
- [x] All 150 vitest tests pass
- [x] All 4 diacritic E2E tests pass  
- [ ] Manual: tap keys on mobile after using diacritic popup — should work normally
- [ ] Manual: long-press diacritic key, select variant, then tap normal keys — should work