### PR TITLE
experiment: single-language meta descriptions for de/fr/nl

### DIFF
--- a/data/languages/de/language_config.json
+++ b/data/languages/de/language_config.json
@@ -20,7 +20,7 @@
     "meta": {
         "locale": "de",
         "title": "Das tägliche Wortspiel",
-        "description": "Spiele Wordle in 80+ Sprachen — von Arabisch bis Yoruba. Das größte mehrsprachige Wordle. Wortdefinitionen, keine Werbung, kein Login. 8 Spielmodi.",
+        "description": "Wordle auf Deutsch — täglich ein neues 5-Buchstaben-Wort, kostenlos, ohne Anmeldung. Unbegrenzter Modus, 8 Spielmodi, Wortdefinitionen nach jedem Spiel.",
         "keywords": "Deutsch, Englisch, Puzzle, Word, Spiel, Spiel, online, Vermutung, täglich, Ratespiel, wordle",
         "modes": {
             "unlimited": {

--- a/data/languages/fr/language_config.json
+++ b/data/languages/fr/language_config.json
@@ -38,7 +38,7 @@
     "meta": {
         "locale": "fr",
         "title": "Le jeu de mots quotidien",
-        "description": "Jouez à Wordle en plus de 80 langues — de l'arabe au yoruba. Le plus grand Wordle multilingue. Définitions, sans pub, sans compte. 8 modes de jeu.",
+        "description": "Wordle en français — un nouveau mot de 5 lettres chaque jour, gratuit, sans inscription. Mode illimité, 8 modes de jeu, définitions après chaque partie.",
         "keywords": "français, puzzle, mot, jouer, jeu, en ligne, devinez, quotidiennement",
         "modes": {
             "unlimited": {

--- a/data/languages/nl/language_config.json
+++ b/data/languages/nl/language_config.json
@@ -38,7 +38,7 @@
     "meta": {
         "locale": "nl",
         "title": "Het dagelijkse woordspel",
-        "description": "Speel Wordle in 80+ talen — van Arabisch tot Yoruba. De grootste meertalige Wordle. Woorddefinities, geen advertenties, geen login. 8 spelmodi.",
+        "description": "Wordle in het Nederlands — elke dag een nieuw woord van 5 letters, gratis, geen account. Onbeperkte modus, 8 spelmodi, woorddefinities na elke ronde.",
         "keywords": "Nederlands, puzzel, woord, spelen, spel, online, raden, dagelijks",
         "modes": {
             "unlimited": {


### PR DESCRIPTION
## Summary

A/B test the multilingual-first vs single-language-first homepage meta description hypothesis. Tests whether the multilingual framing PR #187 shipped is actually right for non-English homepages.

## Background

PR #187 shipped multilingual-first descriptions for the top 10 non-English homepages, e.g.:

\`\`\`
/es: "Juega a Wordle en más de 80 idiomas — del árabe al yoruba…"
\`\`\`

The reasoning was that Google had rewritten our **brand query** (\`wordle global\`) meta to use multilingual framing. I extrapolated from one data point (Google likes multilingual for the brand query) to a recommendation for all homepages. **That extrapolation was unjustified** — the brand query and language-specific queries have different intents.

A user typing \`wordle español\` has signaled they want Spanish wordle, not a polyglot tool. Every successful single-language wordle competitor I curl-checked leads with single-language framing; **none** lead with multilingual:

- Spanish SERP: La Palabra del Día, wordleespanol.org, santiagodebus.com — all single-language
- German SERP: SZ.de, Spiegel — all "Wordle auf Deutsch", no multilingual
- French SERP: SUTOM, others — all single-language

Strong qualitative signal that single-language framing wins for language-specific queries, but I have **zero quantitative evidence**. Hence the experiment.

## Experiment design

| Group | Languages | Style | Sample baseline |
|-------|-----------|-------|-----------------|
| **Control** (multilingual, no change) | \`es\`, \`it\`, \`pt\` | Keep current | ES 1.34% CTR @ pos 6.57 |
| **Treatment** (this PR) | \`de\`, \`fr\`, \`nl\` | Switch to single-language | DE 3.76% CTR @ pos 7.81 |
| **Untouched** (no signal expected) | \`ar\`, \`hr\`, \`fi\`, \`tr\` | n/a — saturated | FI 84% CTR @ pos 1.12 |

3 vs 3, similar combined impression volume, both groups span Romance + Germanic for fair comparison. Saturated markets excluded because their CTRs are pinned at the ceiling.

## Treatment descriptions (LLM, native review pending)

\`\`\`
de: Wordle auf Deutsch — täglich ein neues 5-Buchstaben-Wort, kostenlos, ohne
    Anmeldung. Unbegrenzter Modus, 8 Spielmodi, Wortdefinitionen nach jedem
    Spiel.   (152 chars)

fr: Wordle en français — un nouveau mot de 5 lettres chaque jour, gratuit, sans
    inscription. Mode illimité, 8 modes de jeu, définitions après chaque
    partie.   (152 chars)

nl: Wordle in het Nederlands — elke dag een nieuw woord van 5 letters, gratis,
    geen account. Onbeperkte modus, 8 spelmodi, woorddefinities na elke
    ronde.   (149 chars)
\`\`\`

All under Google's ~160-char display cap. Each leads with the language name, mentions daily/free/no-account upfront, then closes with the differentiators (unlimited mode, 8 modes, definitions).

## Measurement schedule

| Date | Action |
|------|--------|
| Apr 9 | Ship this PR |
| Apr 16 | First GSC check — verify Google reindexed |
| Apr 23 | Early CTR signal (2 weeks) |
| **May 7** | **Primary measurement** — compare control vs treatment delta |
| May 21 | Final assessment, roll out winner or revert |

## Decision rule

- **Treatment lifts ≥0.5pp more than control on average** → roll out single-language framing to all non-English homepages
- **Treatment lifts ≤0pp more than control** → revert treatment to multilingual
- **Mixed signal** → investigate per-language

## Test plan

- [x] \`uv run pytest tests/test_language_config.py\` — 1,417 pass
- [x] All 3 descriptions validated as JSON, under 160 chars
- [ ] Post-deploy: curl prod to confirm new descriptions live
- [ ] May 7: GSC export and CTR delta comparison

Full design + measurement notes in \`docs/seo-ctr-tracking-2026-04-08.md\` (gitignored, local only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated descriptions for German, French, and Dutch versions to better reflect local features and enhance user experience. Each description now highlights a daily word game in the respective language, free play without account creation, unlimited play mode, 8 available game modes, and word definitions displayed after completing each game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->