### PR TITLE
fix: semantic modal routing, remove win overlay, tighten mobile header

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -691,6 +691,25 @@ input:focus-visible {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   Content reveal — smooth entrance for auth-dependent sections
+   Usage: <Transition name="reveal"><div v-if="ready">...</div></Transition>
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.reveal-enter-active {
+    transition: opacity 350ms ease, transform 350ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.reveal-leave-active {
+    transition: opacity 150ms ease;
+}
+.reveal-enter-from {
+    opacity: 0;
+    transform: translateY(8px);
+}
+.reveal-leave-to {
+    opacity: 0;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    View Transitions API — shared element animations (Tier 3)
 
    Active in Chrome 111+, Safari 18+, Firefox 134+. Browsers without

--- a/components/account/LoginModal.vue
+++ b/components/account/LoginModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal :visible="visible" size="sm" @close="$emit('close')">
+    <BaseModal :visible="visible" size="sm" @close="$emit('close')">
         <div class="flex flex-col gap-4">
             <h3 class="heading-section text-xl text-ink">Sign In</h3>
             <p class="text-sm text-muted -mt-2">Sync your stats across devices and earn badges.</p>
@@ -53,7 +53,7 @@
                 <span class="mono-label ml-1">soon</span>
             </button>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/app/AppHeader.vue
+++ b/components/app/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
     <header
-        class="relative flex flex-row items-center h-[50px] px-3 lg:px-2 bg-paper dark:bg-paper editorial-rule"
+        class="relative flex flex-row items-center h-[50px] px-1.5 sm:px-3 lg:px-2 bg-paper dark:bg-paper editorial-rule"
         :style="{ viewTransitionName: logoMode ? 'landing-header' : 'header' }"
     >
         <!-- Left: Menu toggle + Info (game pages only) -->

--- a/components/app/BoardPickerModal.vue
+++ b/components/app/BoardPickerModal.vue
@@ -6,7 +6,7 @@
 -->
 
 <template>
-    <SharedBaseModal
+    <BaseModal
         :visible="visible"
         size="lg"
         align="top"
@@ -61,7 +61,7 @@
                 </div>
             </div>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/app/GameModePicker.vue
+++ b/components/app/GameModePicker.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal
+    <BaseModal
         :visible="visible"
         size="lg"
         align="top"
@@ -73,7 +73,7 @@
                 </div>
             </button>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/app/LanguagePickerModal.vue
+++ b/components/app/LanguagePickerModal.vue
@@ -7,7 +7,7 @@
 -->
 
 <template>
-    <SharedBaseModal
+    <BaseModal
         :visible="visible"
         size="lg"
         align="top"
@@ -50,7 +50,7 @@
                 No languages match "{{ searchQuery }}"
             </div>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/game/BestStartingWordsPanel.vue
+++ b/components/game/BestStartingWordsPanel.vue
@@ -58,7 +58,7 @@ const copy = computed(() => {
         <p class="text-xs text-muted leading-relaxed max-w-lg mx-auto text-center">
             {{ copy.subtitle }}
         </p>
-        <SharedStartingWordsList :words="topWords" compact :coverage-label="copy.coverageLabel" />
+        <StartingWordsList :words="topWords" compact :coverage-label="copy.coverageLabel" />
         <p class="text-center">
             <a
                 :href="`/${lang}/best-starting-words`"

--- a/components/game/CopyFallbackModal.vue
+++ b/components/game/CopyFallbackModal.vue
@@ -1,9 +1,5 @@
 <template>
-    <SharedBaseModal
-        :visible="!!game.copyFallbackText"
-        size="sm"
-        @close="game.closeCopyFallbackModal()"
-    >
+    <BaseModal :visible="!!game.copyFallbackText" size="sm" @close="game.closeCopyFallbackModal()">
         <div class="text-center">
             <p class="font-body font-semibold text-ink mb-3">Copy your results:</p>
             <textarea
@@ -20,7 +16,7 @@
                 Done
             </button>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/game/HelpModal.vue
+++ b/components/game/HelpModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal :visible="visible" size="md" @close="$emit('close')">
+    <BaseModal :visible="visible" size="md" @close="$emit('close')">
         <div class="flex flex-col gap-2">
             <!-- Speed Streak help -->
             <template v-if="isSpeedMode">
@@ -205,7 +205,7 @@
                 </div>
             </template>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/game/PageShell.vue
+++ b/components/game/PageShell.vue
@@ -33,7 +33,7 @@
                         :just-won="justWon"
                         :show-results="true"
                         @help="onHelp"
-                        @results="game.showStatsModal = !game.showStatsModal"
+                        @results="onResults"
                         @streak="game.showStreakModal = !game.showStreakModal"
                         @settings="game.showOptionsModal = !game.showOptionsModal"
                         @toggle-sidebar="$emit('toggleSidebar')"
@@ -85,6 +85,7 @@
                     @close="game.showOptionsModal = false"
                 />
                 <GameStatsModal
+                    v-if="!noKeyboard"
                     :visible="game.showStatsModal"
                     @close="game.showStatsModal = false"
                     @new-game="
@@ -171,7 +172,7 @@ const props = withDefaults(
     }
 );
 
-const emit = defineEmits<{ toggleSidebar: []; closeSidebar: []; newGame: [] }>();
+const emit = defineEmits<{ toggleSidebar: []; closeSidebar: []; newGame: []; results: [] }>();
 
 const game = useGameStore();
 
@@ -277,6 +278,16 @@ watch(
 
 function onHelp() {
     game.showHelpModal = !game.showHelpModal;
+}
+
+// noKeyboard modes (semantic) handle their own results modal — emit
+// so the page can open its specific modal instead of the generic one.
+function onResults() {
+    if (props.noKeyboard) {
+        emit('results');
+    } else {
+        game.showStatsModal = !game.showStatsModal;
+    }
 }
 
 const maxWidthClass = computed(() => {

--- a/components/game/SettingsModal.vue
+++ b/components/game/SettingsModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal :visible="visible" size="sm" @close="$emit('close')">
+    <BaseModal :visible="visible" size="sm" @close="$emit('close')">
         <div class="flex flex-col gap-2">
             <h3 class="heading-section text-xl text-ink mb-5">
                 {{ lang.config?.ui?.settings || 'Settings' }}
@@ -13,7 +13,7 @@
                             {{ lang.config?.ui?.dark_mode || 'Dark Mode' }}
                         </p>
                     </div>
-                    <SharedToggleSwitch
+                    <ToggleSwitch
                         :model-value="settings.darkMode"
                         @update:model-value="settings.toggleDarkMode()"
                     />
@@ -28,7 +28,7 @@
                             {{ lang.config?.ui?.sound_and_haptics || 'Sound & Haptics' }}
                         </p>
                     </div>
-                    <SharedToggleSwitch
+                    <ToggleSwitch
                         :model-value="settings.feedbackEnabled"
                         @update:model-value="settings.toggleFeedback()"
                     />
@@ -112,7 +112,7 @@
                             }}
                         </p>
                     </div>
-                    <SharedToggleSwitch
+                    <ToggleSwitch
                         :model-value="settings.wordInfoEnabled"
                         @update:model-value="settings.toggleWordInfo()"
                     />
@@ -133,7 +133,7 @@
                             }}
                         </p>
                     </div>
-                    <SharedToggleSwitch
+                    <ToggleSwitch
                         :model-value="settings.animationsEnabled"
                         @update:model-value="settings.toggleAnimations()"
                     />
@@ -153,7 +153,7 @@
                             }}
                         </p>
                     </div>
-                    <SharedToggleSwitch
+                    <ToggleSwitch
                         :model-value="settings.highContrast"
                         @update:model-value="settings.toggleHighContrast()"
                     />
@@ -236,7 +236,7 @@
                 </div>
             </div>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/game/SpeedResults.vue
+++ b/components/game/SpeedResults.vue
@@ -21,7 +21,7 @@ defineEmits<{
 </script>
 
 <template>
-    <SharedBaseModal :visible="visible" size="sm" @close="$emit('close')">
+    <BaseModal :visible="visible" size="sm" @close="$emit('close')">
         <h2 class="heading-section text-2xl text-center text-ink mb-1">Speed Streak</h2>
         <p class="text-center text-muted text-sm mb-3">Time's up!</p>
 
@@ -92,5 +92,5 @@ defineEmits<{
                 Play Again
             </button>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>

--- a/components/game/StatsModal.vue
+++ b/components/game/StatsModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal
+    <BaseModal
         :visible="visible"
         size="xl"
         align="top"
@@ -352,7 +352,7 @@
                 v-html="game.timeUntilNextDay"
             />
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/game/StreakModal.vue
+++ b/components/game/StreakModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <SharedBaseModal :visible="visible" size="sm" @close="$emit('close')">
+    <BaseModal :visible="visible" size="sm" @close="$emit('close')">
         <div class="flex flex-col gap-0">
             <!-- Hero -->
             <div class="text-center mb-4">
@@ -23,7 +23,7 @@
 
             <!-- Calendar heatmap (shared component) -->
             <div class="py-3">
-                <SharedStreakCalendar
+                <StreakCalendar
                     :game-results="statsStore.gameResults as Record<string, GameResult[]>"
                 />
             </div>
@@ -66,7 +66,7 @@
                 </button>
             </ClientOnly>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <script setup lang="ts">

--- a/components/semantic/SemanticInput.vue
+++ b/components/semantic/SemanticInput.vue
@@ -48,6 +48,24 @@ watch(
     { immediate: true }
 );
 
+// On mobile, the virtual keyboard opens and the browser scrolls the nearest
+// scrollable ancestor to keep the input visible. But the input is position:fixed
+// on mobile — it doesn't need scrolling. Lock scroll position on focus, restore on blur.
+let savedScrollTop = 0;
+function onFocus() {
+    if (!isTouch) return;
+    const scrollable = inputRef.value?.closest('.semantic-body') as HTMLElement | null;
+    if (scrollable) {
+        savedScrollTop = scrollable.scrollTop;
+        requestAnimationFrame(() => {
+            scrollable.scrollTop = savedScrollTop;
+        });
+    }
+}
+function onBlur() {
+    // No action needed — scroll is already at the saved position
+}
+
 defineExpose({
     focus: () => inputRef.value?.focus(),
 });
@@ -69,6 +87,8 @@ defineExpose({
                 autocorrect="off"
                 spellcheck="false"
                 inputmode="text"
+                @focus="onFocus"
+                @blur="onBlur"
             />
             <button type="submit" class="guess-button" :disabled="!value || loading || disabled">
                 <span v-if="loading">…</span>

--- a/components/semantic/SemanticStatsModal.vue
+++ b/components/semantic/SemanticStatsModal.vue
@@ -47,13 +47,6 @@ function onShareClick() {
     }, 2000);
 }
 
-function rankColor(rank: number): string {
-    if (rank <= 10) return 'text-correct';
-    if (rank <= 50) return 'text-semicorrect';
-    if (rank <= 200) return 'text-accent';
-    return 'text-muted';
-}
-
 const bestRank = computed(() => {
     if (!props.guesses.length) return null;
     return Math.min(...props.guesses.map((g) => g.rank));

--- a/components/semantic/SemanticStatsModal.vue
+++ b/components/semantic/SemanticStatsModal.vue
@@ -8,7 +8,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { Sparkles, Trophy, XCircle } from 'lucide-vue-next';
+import { Sparkles, Trophy, XCircle, Share2, Check } from 'lucide-vue-next';
 import type { Neighbour, SemanticGuess } from '~/composables/useSemanticGame';
 import { wordDetailPath } from '~/utils/wordUrls';
 
@@ -54,12 +54,7 @@ const bestRank = computed(() => {
 </script>
 
 <template>
-    <SharedBaseModal
-        :visible="visible"
-        size="lg"
-        label-id="semantic-stats-label"
-        @close="emit('close')"
-    >
+    <BaseModal :visible="visible" size="lg" label-id="semantic-stats-label" @close="emit('close')">
         <div class="stats-body">
             <!-- Header -->
             <div class="stats-header">
@@ -123,25 +118,41 @@ const bestRank = computed(() => {
                 </div>
             </div>
 
-            <!-- Actions -->
-            <div class="action-row">
+            <!-- Actions — matches classic StatsModal pattern -->
+            <div class="flex gap-3 stats-actions">
+                <button
+                    type="button"
+                    class="flex-1 stats-btn bg-ink text-paper font-body text-sm font-semibold tracking-wide transition-opacity hover:opacity-85 cursor-pointer inline-flex items-center justify-center gap-2"
+                    @click="onShareClick"
+                >
+                    <template v-if="shareCopied">
+                        <Check :size="16" />
+                        Copied!
+                    </template>
+                    <template v-else>
+                        <Share2 :size="16" />
+                        Share Result
+                    </template>
+                </button>
                 <button
                     v-if="isDaily"
                     type="button"
-                    class="btn btn-ghost"
+                    class="flex-1 stats-btn border border-ink text-ink font-body text-sm font-semibold tracking-wide transition-all hover:bg-ink hover:text-paper text-center cursor-pointer whitespace-nowrap"
                     @click="emit('keepPlaying')"
                 >
                     Keep Playing
                 </button>
-                <button v-else type="button" class="btn btn-ghost" @click="emit('newGame')">
+                <button
+                    v-else
+                    type="button"
+                    class="flex-1 stats-btn border border-ink text-ink font-body text-sm font-semibold tracking-wide transition-all hover:bg-ink hover:text-paper text-center cursor-pointer whitespace-nowrap"
+                    @click="emit('newGame')"
+                >
                     Play Again
-                </button>
-                <button type="button" class="btn btn-primary" @click="onShareClick">
-                    {{ shareCopied ? 'Copied!' : 'Share result' }}
                 </button>
             </div>
         </div>
-    </SharedBaseModal>
+    </BaseModal>
 </template>
 
 <style scoped>
@@ -246,54 +257,6 @@ const bestRank = computed(() => {
 .section-label {
     margin-bottom: 8px;
 }
-.guess-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    max-height: 220px;
-    overflow-y: auto;
-    border: 1px solid var(--color-rule);
-}
-.guess-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 6px 12px;
-    border-bottom: 1px solid var(--color-rule);
-    font-size: 14px;
-}
-.guess-item:last-child {
-    border-bottom: none;
-}
-.guess-num {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    color: var(--color-muted);
-    width: 20px;
-}
-.guess-word {
-    font-family: var(--font-display);
-    font-weight: 600;
-    flex: 1;
-}
-.guess-sim {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
-}
-.text-correct {
-    color: var(--color-correct);
-    font-weight: 600;
-}
-.text-semicorrect {
-    color: var(--color-semicorrect);
-}
-.text-accent {
-    color: var(--color-hot);
-}
-.text-muted {
-    color: var(--color-muted);
-}
 .neighbour-grid {
     display: flex;
     flex-wrap: wrap;
@@ -315,36 +278,11 @@ const bestRank = computed(() => {
     font-size: 10px;
     color: var(--color-muted);
 }
-.action-row {
-    display: flex;
-    gap: 8px;
-    margin-top: 4px;
+/* Action buttons — same sizing as classic StatsModal */
+.stats-actions {
+    padding: 20px 0 0;
 }
-.btn {
-    flex: 1;
-    padding: 12px 16px;
-    font-family: var(--font-body);
-    font-size: 14px;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    cursor: pointer;
-    border-radius: 0;
-}
-.btn-primary {
-    background: var(--color-ink);
-    color: var(--color-paper);
-    border: 2px solid var(--color-ink);
-}
-.btn-primary:hover {
-    opacity: 0.85;
-}
-.btn-ghost {
-    background: transparent;
-    color: var(--color-ink);
-    border: 2px solid var(--color-rule);
-}
-.btn-ghost:hover {
-    border-color: var(--color-ink);
+.stats-btn {
+    padding: 12px 20px;
 }
 </style>

--- a/components/shared/RevealTransition.vue
+++ b/components/shared/RevealTransition.vue
@@ -1,0 +1,17 @@
+<!--
+  RevealTransition — smooth fade+slide entrance for content that appears asynchronously.
+
+  Wraps Vue's <Transition> with the "reveal" animation (350ms fade + 8px slide up).
+  Use for auth-dependent sections, async-loaded content, or anything that
+  pops into existence after initial render.
+
+  Usage:
+    <RevealTransition>
+      <div v-if="loaded">...</div>
+    </RevealTransition>
+-->
+<template>
+    <Transition name="reveal" appear>
+        <slot />
+    </Transition>
+</template>

--- a/composables/useDayRollover.ts
+++ b/composables/useDayRollover.ts
@@ -1,0 +1,43 @@
+/**
+ * Day rollover detection — reloads the page when the daily word changes.
+ *
+ * Listens for visibilitychange and checks if the server's day index has
+ * advanced since the page loaded. If so, forces a full page reload to
+ * pick up the new word. Prevents stale game state where a user plays
+ * against yesterday's word with today's coloring (or vice versa).
+ *
+ * Only active on daily game modes — unlimited/speed don't have day indices.
+ */
+export function useDayRollover(lang: string, loadedDayIdx: number) {
+    if (!import.meta.client) return;
+
+    let checking = false;
+
+    async function checkRollover() {
+        if (checking) return;
+        if (document.visibilityState !== 'visible') return;
+
+        checking = true;
+        try {
+            const res = await $fetch<{ todays_idx: number }>(`/api/${lang}/data`, {
+                query: { minimal: '1' },
+                // Bypass Nuxt's useFetch cache
+                headers: { 'Cache-Control': 'no-cache' },
+            });
+            if (res.todays_idx !== loadedDayIdx) {
+                // Day rolled over — reload to get the new word
+                window.location.reload();
+            }
+        } catch {
+            // Network error — don't reload, user can keep playing
+        } finally {
+            checking = false;
+        }
+    }
+
+    document.addEventListener('visibilitychange', checkRollover);
+
+    onUnmounted(() => {
+        document.removeEventListener('visibilitychange', checkRollover);
+    });
+}

--- a/composables/useGameLifecycle.ts
+++ b/composables/useGameLifecycle.ts
@@ -1,0 +1,80 @@
+/**
+ * useGameLifecycle — shared game result handling for all modes.
+ *
+ * Centralizes:
+ *   - Saving results to localStorage (stats store)
+ *   - Syncing results to the server (logged-in users)
+ *   - Recalculating stats after save
+ *   - Duplicate-save guards (won't re-save on state restore)
+ *
+ * Architecture note: tile-based modes (classic, dordle, quordle, etc.)
+ * signal game-over via `game.gameOver` in the Pinia store, and useSync.ts
+ * watches that flag for server sync. Non-tile modes (Semantic Explorer)
+ * have their own state machine and must call handleGameOver() directly.
+ * This composable is the single source of truth for result persistence
+ * regardless of which state machine triggers it.
+ */
+import { buildStatsKey } from '~/utils/game-modes';
+import type { GameConfig } from '~/utils/game-modes';
+
+interface GameOverEvent {
+    won: boolean;
+    attempts: number;
+    /** True if this game-over was restored from localStorage (not live) */
+    isRestore: boolean;
+}
+
+/**
+ * Call this when a non-tile game mode ends (win or loss).
+ * Handles localStorage save, server sync, and stats recalculation.
+ * No-ops on restore to prevent duplicate saves.
+ */
+export function useGameLifecycle() {
+    const stats = useStatsStore();
+    const { loggedIn } = useAuth();
+
+    function handleGameOver(config: GameConfig, event: GameOverEvent) {
+        if (event.isRestore) return;
+
+        const statsKey = buildStatsKey(config);
+
+        // Save to localStorage
+        try {
+            stats.saveResult(statsKey, event.won, event.attempts);
+            stats.calculateStats(statsKey, config.maxGuesses);
+        } catch (e) {
+            console.warn('[game-lifecycle] stats save failed', e);
+        }
+
+        // Sync to server
+        if (loggedIn.value) {
+            const dayIdx = config.playType === 'daily' ? config.dayIndex : undefined;
+            $fetch('/api/user/game-result', {
+                method: 'POST',
+                body: {
+                    statsKey,
+                    won: event.won,
+                    attempts: event.attempts,
+                    dayIdx,
+                    game_mode: config.mode,
+                    play_type: config.playType,
+                },
+            }).catch(() => {
+                /* non-fatal — will sync on next full sync */
+            });
+        }
+    }
+
+    /** Load and calculate stats for a mode on page mount. */
+    function initStats(langCode: string, config: GameConfig) {
+        try {
+            stats.loadGameResults(langCode);
+            stats.calculateStats(buildStatsKey(config), config.maxGuesses);
+            stats.calculateTotalStats();
+        } catch {
+            /* non-fatal */
+        }
+    }
+
+    return { handleGameOver, initStats };
+}

--- a/composables/useGameLifecycle.ts
+++ b/composables/useGameLifecycle.ts
@@ -1,18 +1,16 @@
 /**
- * useGameLifecycle — shared game result handling for all modes.
+ * useGameLifecycle — single source of truth for game result persistence.
+ *
+ * All game modes funnel results through this composable:
+ *   - Tile modes (classic, dordle, etc.): useSync watches game.gameOver → calls syncGameResult()
+ *   - Semantic: semantic page watches sem.gameOver → calls handleGameOver()
+ *   - Speed: useSync watches speedResults count → calls syncSpeedResult()
  *
  * Centralizes:
  *   - Saving results to localStorage (stats store)
- *   - Syncing results to the server (logged-in users)
+ *   - Syncing results to the server (with badge notification + offline queue)
  *   - Recalculating stats after save
  *   - Duplicate-save guards (won't re-save on state restore)
- *
- * Architecture note: tile-based modes (classic, dordle, quordle, etc.)
- * signal game-over via `game.gameOver` in the Pinia store, and useSync.ts
- * watches that flag for server sync. Non-tile modes (Semantic Explorer)
- * have their own state machine and must call handleGameOver() directly.
- * This composable is the single source of truth for result persistence
- * regardless of which state machine triggers it.
  */
 import { buildStatsKey } from '~/utils/game-modes';
 import type { GameConfig } from '~/utils/game-modes';
@@ -24,15 +22,27 @@ interface GameOverEvent {
     isRestore: boolean;
 }
 
+interface SyncOptions {
+    /** Device ID for deduplication */
+    deviceId?: string;
+    /** Callback when sync fails — add to pending queue for offline retry */
+    onSyncFail?: (payload: { endpoint: string; body: unknown; addedAt: string }) => void;
+    /** Callback when new badges are earned */
+    onNewBadges?: (badges: Array<{ slug: string; name: string }>) => void;
+}
+
 /**
- * Call this when a non-tile game mode ends (win or loss).
- * Handles localStorage save, server sync, and stats recalculation.
- * No-ops on restore to prevent duplicate saves.
+ * Shared game lifecycle — used by both page-level code (semantic)
+ * and the sync plugin (tile modes). Single place for result handling.
  */
-export function useGameLifecycle() {
+export function useGameLifecycle(syncOpts: SyncOptions = {}) {
     const stats = useStatsStore();
     const { loggedIn } = useAuth();
 
+    /**
+     * Handle game-over for non-speed modes. Saves to localStorage,
+     * syncs to server, recalculates stats. No-ops on restore.
+     */
     function handleGameOver(config: GameConfig, event: GameOverEvent) {
         if (event.isRestore) return;
 
@@ -47,22 +57,57 @@ export function useGameLifecycle() {
         }
 
         // Sync to server
-        if (loggedIn.value) {
-            const dayIdx = config.playType === 'daily' ? config.dayIndex : undefined;
-            $fetch('/api/user/game-result', {
-                method: 'POST',
-                body: {
-                    statsKey,
-                    won: event.won,
-                    attempts: event.attempts,
-                    dayIdx,
-                    game_mode: config.mode,
-                    play_type: config.playType,
-                },
-            }).catch(() => {
-                /* non-fatal — will sync on next full sync */
+        syncGameResult({
+            statsKey,
+            won: event.won,
+            attempts: event.attempts,
+            dayIdx: config.playType === 'daily' ? config.dayIndex : undefined,
+            game_mode: config.mode,
+            play_type: config.playType,
+        });
+    }
+
+    /**
+     * Sync a game result to the server. Handles auth check, badge
+     * notifications, and offline queue. Used by both handleGameOver()
+     * and useSync's tile-mode watcher.
+     */
+    function syncGameResult(body: Record<string, unknown>) {
+        if (!loggedIn.value) return;
+
+        const requestBody = { ...body, deviceId: syncOpts.deviceId };
+
+        $fetch('/api/user/game-result', {
+            method: 'POST',
+            body: requestBody,
+        })
+            .then((res: any) => {
+                if (res?.newBadges?.length && syncOpts.onNewBadges) {
+                    syncOpts.onNewBadges(res.newBadges);
+                }
+            })
+            .catch(() => {
+                if (syncOpts.onSyncFail) {
+                    syncOpts.onSyncFail({
+                        endpoint: '/api/user/game-result',
+                        body: requestBody,
+                        addedAt: new Date().toISOString(),
+                    });
+                }
             });
-        }
+    }
+
+    /**
+     * Sync a speed result to the server. Called by useSync's speed watcher.
+     */
+    function syncSpeedResult(body: Record<string, unknown>) {
+        if (!loggedIn.value) return;
+        $fetch('/api/user/speed-result', {
+            method: 'POST',
+            body: { ...body, deviceId: syncOpts.deviceId },
+        }).catch(() => {
+            /* speed results don't queue for retry */
+        });
     }
 
     /** Load and calculate stats for a mode on page mount. */
@@ -76,5 +121,5 @@ export function useGameLifecycle() {
         }
     }
 
-    return { handleGameOver, initStats };
+    return { handleGameOver, syncGameResult, syncSpeedResult, initStats };
 }

--- a/composables/useMultiBoardPage.ts
+++ b/composables/useMultiBoardPage.ts
@@ -76,8 +76,18 @@ export function useMultiBoardPage(
     }
 
     // Initialize boards synchronously so SSR/first render has correct board count.
-    // This prevents the flash of a single-board layout before hydration.
-    if (wordList.length > 0) {
+    // For daily mode, try to restore a completed game from localStorage first
+    // (same pattern as classic daily's loadFromLocalStorage).
+    let restored = false;
+    if (dailyWords?.length === boardCount && import.meta.client) {
+        try {
+            restored = game.loadMultiBoardFromLocalStorage(mode, dailyWords, 'daily');
+        } catch {
+            // Restoration failed — will start fresh below
+        }
+    }
+
+    if (!restored && wordList.length > 0) {
         try {
             startNewGame();
         } catch {

--- a/composables/useSync.ts
+++ b/composables/useSync.ts
@@ -56,49 +56,37 @@ export function useSync() {
     }
 
     // -----------------------------------------------------------------
-    // Per-game sync: watch gameOver to push individual results
+    // Per-game sync via shared lifecycle (DRY: one place for server sync)
     // -----------------------------------------------------------------
 
+    const lifecycle = useGameLifecycle({
+        deviceId,
+        onSyncFail: (item) => addToPendingQueue(item as PendingSyncItem),
+        onNewBadges: (badges) => {
+            const { addBadges } = useBadgeNotification();
+            addBadges(badges);
+        },
+    });
+
     if (import.meta.client) {
+        // Tile-based modes: watch game.gameOver
         watch(
             () => game.gameOver,
             (isOver) => {
                 if (!isOver || !loggedIn.value) return;
-                if (game.gameConfig.mode === 'speed') return; // Speed handled separately
+                if (game.gameConfig.mode === 'speed') return;
 
-                const statsKey = buildStatsKey(game.gameConfig);
                 const lang = useLanguageStore();
-                const dayIdx = game.gameConfig.playType === 'daily' ? lang.todaysIdx : undefined;
-
-                const requestBody = {
-                    statsKey,
+                lifecycle.syncGameResult({
+                    statsKey: buildStatsKey(game.gameConfig),
                     won: game.gameWon,
                     attempts: Number(game.attempts) || 0,
-                    dayIdx,
-                    deviceId,
-                };
-
-                $fetch('/api/user/game-result', {
-                    method: 'POST',
-                    body: requestBody,
-                })
-                    .then((res) => {
-                        if (res?.newBadges?.length) {
-                            const { addBadges } = useBadgeNotification();
-                            addBadges(res.newBadges);
-                        }
-                    })
-                    .catch(() => {
-                        addToPendingQueue({
-                            endpoint: '/api/user/game-result',
-                            body: requestBody,
-                            addedAt: new Date().toISOString(),
-                        });
-                    });
+                    dayIdx: game.gameConfig.playType === 'daily' ? lang.todaysIdx : undefined,
+                });
             }
         );
 
-        // Speed results: watch the stats store's speedResults for new entries
+        // Speed results: watch for new entries
         watch(
             () => Object.values(stats.speedResults).reduce((sum, arr) => sum + arr.length, 0),
             (newCount) => {
@@ -108,7 +96,6 @@ export function useSync() {
                 }
                 prevSpeedCount = newCount;
 
-                // Find the most recent speed result across all languages
                 let latest: {
                     lang: string;
                     result: (typeof stats.speedResults)[string][number];
@@ -123,18 +110,14 @@ export function useSync() {
                 }
 
                 if (latest) {
-                    $fetch('/api/user/speed-result', {
-                        method: 'POST',
-                        body: {
-                            lang: latest.lang,
-                            score: latest.result.score,
-                            wordsSolved: latest.result.wordsSolved,
-                            wordsFailed: latest.result.wordsFailed,
-                            maxCombo: latest.result.maxCombo,
-                            totalGuesses: latest.result.totalGuesses,
-                            deviceId,
-                        },
-                    }).catch(() => {});
+                    lifecycle.syncSpeedResult({
+                        lang: latest.lang,
+                        score: latest.result.score,
+                        wordsSolved: latest.result.wordsSolved,
+                        wordsFailed: latest.result.wordsFailed,
+                        maxCombo: latest.result.maxCombo,
+                        totalGuesses: latest.result.totalGuesses,
+                    });
                 }
             }
         );

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,8 @@ export default defineNuxtConfig({
 
     modules: ['@pinia/nuxt', '@vite-pwa/nuxt', '@posthog/nuxt', 'nuxt-auth-utils'],
 
+    components: [{ path: '~/components/shared', pathPrefix: false }, '~/components'],
+
     auth: {
         webAuthn: true,
     },

--- a/pages/[lang]/[mode].vue
+++ b/pages/[lang]/[mode].vue
@@ -41,6 +41,11 @@ const { langStore, game, sidebarOpen, toggleSidebar, closeSidebar, config } = us
     lang
 );
 
+// Detect day rollover when tab regains focus
+if (isDaily.value) {
+    useDayRollover(lang, gameData.value!.todays_idx);
+}
+
 // Set the game config with the correct play type
 const modeConfig = createGameConfig(mode, lang, {
     playType: playType.value,

--- a/pages/[lang]/best-starting-words.vue
+++ b/pages/[lang]/best-starting-words.vue
@@ -148,10 +148,7 @@ useHead({
                 <h2 class="heading-section text-xl text-ink">
                     Top {{ Math.min(topWords.length, 10) }} Starting Words
                 </h2>
-                <SharedStartingWordsList
-                    :words="topWords.slice(0, 10)"
-                    :coverage-label="coverageLabel"
-                />
+                <StartingWordsList :words="topWords.slice(0, 10)" :coverage-label="coverageLabel" />
                 <p class="text-xs text-muted leading-relaxed">
                     Coverage score = sum of letter frequency percentages for each unique letter.
                     Higher means the word tests more commonly-used letters in {{ langName }} Wordle.

--- a/pages/[lang]/index.vue
+++ b/pages/[lang]/index.vue
@@ -54,6 +54,9 @@ if (error.value || !gameData.value) {
 const { langStore, game, stats, sidebarOpen, toggleSidebar, closeSidebar, gameBoardRef, config } =
     useGamePage(gameData, lang);
 
+// Detect day rollover when tab regains focus (prevents stale word coloring)
+useDayRollover(lang, gameData.value!.todays_idx);
+
 // --- SEO ---
 const configVal = gameData.value.config;
 const seo = useGameSeo({

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -129,6 +129,7 @@ onMounted(async () => {
     }
     try {
         stats.loadGameResults(langStore.languageCode);
+        stats.calculateStats(buildStatsKey(game.gameConfig), 15);
         stats.calculateTotalStats();
     } catch {
         /* non-fatal */
@@ -182,23 +183,44 @@ watch(
             return;
         }
 
-        if (sem.neighbours.value.length > 0) {
+        const isRestore = sem.neighbours.value.length > 0;
+
+        if (isRestore) {
             // Restored from localStorage — show instantly, auto-open modal for daily
             revealedNeighbourCount.value = sem.neighbours.value.length;
             if (isDaily.value) showStatsModal.value = true;
-        } else {
-            // Live game-over — stagger once neighbours arrive
-            needsStagger = true;
+            return; // Don't re-save stats or re-track analytics
         }
 
+        // Live game-over — stagger neighbours once they arrive
+        needsStagger = true;
+
+        // Save to localStorage
+        const statsKey = buildStatsKey(game.gameConfig);
         try {
-            stats.saveResult(
-                buildStatsKey(game.gameConfig),
-                sem.won.value,
-                sem.guesses.value.length
-            );
+            stats.saveResult(statsKey, sem.won.value, sem.guesses.value.length);
+            stats.calculateStats(statsKey, 15);
         } catch (e) {
             console.warn('[semantic] stats save failed', e);
+        }
+
+        // Sync to server (semantic doesn't use game store's gameOver,
+        // so the sync plugin's watcher doesn't fire — we sync directly)
+        if (useAuth().loggedIn.value) {
+            const dayIdx = isDaily.value ? sem.dayIdx.value : undefined;
+            $fetch('/api/user/game-result', {
+                method: 'POST',
+                body: {
+                    statsKey,
+                    won: sem.won.value,
+                    attempts: sem.guesses.value.length,
+                    dayIdx,
+                    game_mode: 'semantic',
+                    play_type: playType.value,
+                },
+            }).catch(() => {
+                /* non-fatal — will sync on next full sync */
+            });
         }
 
         // Analytics
@@ -692,6 +714,9 @@ function onKeepPlaying() {
 @media (max-width: 520px) {
     .semantic-body {
         padding: 8px 4px 16px;
+        /* Prevent keyboard-open scroll: input is position:fixed,
+           so the body doesn't need to scroll to show it. */
+        overflow-y: hidden;
     }
     .semantic-layout {
         gap: 8px;

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -386,6 +386,7 @@ function onKeepPlaying() {
         @toggle-sidebar="toggleSidebar"
         @close-sidebar="closeSidebar"
         @new-game="onNewGame"
+        @results="showStatsModal = !showStatsModal"
     >
         <!-- Unavailable state: embeddings not generated yet -->
         <div
@@ -409,7 +410,7 @@ function onKeepPlaying() {
             <section class="semantic-layout">
                 <!-- Main column: map card (title + canvas + input) -->
                 <div class="main-col">
-                    <div class="map-card" :class="{ won: sem.won.value }">
+                    <div class="map-card">
                         <header class="map-header">
                             <div class="map-eyebrow">
                                 <span class="eyebrow-tag">
@@ -459,23 +460,6 @@ function onKeepPlaying() {
                                         :compass-word="sem.bestGuess.value?.word ?? null"
                                         :new-best-signal="sem.newBestSignal.value"
                                     />
-                                    <!-- Win overlay -->
-                                    <transition name="celebrate-fade">
-                                        <div v-if="sem.won.value" class="win-overlay">
-                                            <div class="win-badge">
-                                                <span class="win-label">Found</span>
-                                                <span class="win-word">{{
-                                                    sem.finalTargetWord.value
-                                                }}</span>
-                                                <span class="win-stat">
-                                                    {{ sem.guesses.value.length }}/{{
-                                                        sem.maxGuesses.value
-                                                    }}
-                                                    guesses
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </transition>
                                 </template>
                             </MapFrame>
                         </div>
@@ -601,11 +585,6 @@ function onKeepPlaying() {
     border: 1px solid var(--color-rule);
     padding: 20px 22px 16px;
     position: relative;
-    transition: border-color 400ms ease;
-}
-.map-card.won {
-    border-color: var(--color-correct);
-    box-shadow: 0 0 0 1px var(--color-correct);
 }
 
 .map-header {
@@ -666,48 +645,6 @@ function onKeepPlaying() {
 
 /* Map controls (expand, zoom, pan) are in shared MapFrame component */
 
-/* Win overlay on top of the map canvas */
-.win-overlay {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
-    padding-top: 12px;
-    pointer-events: none;
-}
-.win-badge {
-    background: var(--color-paper);
-    border: 2px solid var(--color-correct);
-    padding: 10px 18px;
-    text-align: center;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-}
-.win-label {
-    font-family: var(--font-mono);
-    font-size: 9px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--color-correct);
-}
-.win-word {
-    font-family: var(--font-display);
-    font-size: 28px;
-    font-weight: 700;
-    color: var(--color-ink);
-    line-height: 1;
-}
-.win-stat {
-    font-family: var(--font-mono);
-    font-size: 10px;
-    color: var(--color-muted);
-    letter-spacing: 0.05em;
-}
-
 .map-input-row {
     /* On desktop, visually attach to the map card above */
     margin-top: -1px;
@@ -727,21 +664,6 @@ function onKeepPlaying() {
 }
 .leaderboard-panel {
     min-height: 180px;
-}
-
-/* ═════════════════════════════════════════════════════════════
-   Transitions
-   ═════════════════════════════════════════════════════════════ */
-.celebrate-fade-enter-active {
-    transition: all 500ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-.celebrate-fade-leave-active {
-    transition: all 300ms ease;
-}
-.celebrate-fade-enter-from,
-.celebrate-fade-leave-to {
-    opacity: 0;
-    transform: translateY(-8px) scale(0.96);
 }
 
 /* ═════════════════════════════════════════════════════════════

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -183,8 +183,6 @@ watch(
 
         const isRestore = sem.neighbours.value.length > 0;
 
-        const isRestore = sem.neighbours.value.length > 0;
-
         if (isRestore) {
             // Restored from localStorage — show instantly, auto-open modal for daily
             revealedNeighbourCount.value = sem.neighbours.value.length;

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -13,7 +13,7 @@
  */
 
 import { computed, onMounted, ref, watch } from 'vue';
-import { buildStatsKey, createGameConfig } from '~/utils/game-modes';
+import { createGameConfig } from '~/utils/game-modes';
 import MapFrame from '~/components/shared/MapFrame.vue';
 import MeaningMap, { type MapDot } from '~/components/shared/MeaningMap.vue';
 import { buildSemanticGradientFromCSS, sampleGradient } from '~/utils/semanticColor';
@@ -115,6 +115,9 @@ const headerSubtitle = computed(() => {
 // --- Stats modal state (local, not from game store) ---
 const showStatsModal = ref(false);
 
+// --- Shared game lifecycle (stats save, server sync, duplicate guard) ---
+const lifecycle = useGameLifecycle();
+
 // --- Staggered neighbour reveal on game over ---
 const NEIGHBOUR_STAGGER_MS = 150;
 const revealedNeighbourCount = ref(0);
@@ -127,13 +130,8 @@ onMounted(async () => {
     } catch {
         /* non-fatal */
     }
-    try {
-        stats.loadGameResults(langStore.languageCode);
-        stats.calculateStats(buildStatsKey(game.gameConfig), 15);
-        stats.calculateTotalStats();
-    } catch {
-        /* non-fatal */
-    }
+
+    lifecycle.initStats(langStore.languageCode, game.gameConfig);
 
     try {
         const analytics = useAnalytics();
@@ -185,56 +183,38 @@ watch(
 
         const isRestore = sem.neighbours.value.length > 0;
 
+        const isRestore = sem.neighbours.value.length > 0;
+
         if (isRestore) {
             // Restored from localStorage — show instantly, auto-open modal for daily
             revealedNeighbourCount.value = sem.neighbours.value.length;
             if (isDaily.value) showStatsModal.value = true;
-            return; // Don't re-save stats or re-track analytics
         }
 
-        // Live game-over — stagger neighbours once they arrive
-        needsStagger = true;
+        // Shared lifecycle: save stats + sync to server (no-ops on restore)
+        lifecycle.handleGameOver(game.gameConfig, {
+            won: sem.won.value,
+            attempts: sem.guesses.value.length,
+            isRestore,
+        });
 
-        // Save to localStorage
-        const statsKey = buildStatsKey(game.gameConfig);
-        try {
-            stats.saveResult(statsKey, sem.won.value, sem.guesses.value.length);
-            stats.calculateStats(statsKey, 15);
-        } catch (e) {
-            console.warn('[semantic] stats save failed', e);
-        }
+        if (!isRestore) {
+            // Live game-over — stagger neighbours once they arrive
+            needsStagger = true;
 
-        // Sync to server (semantic doesn't use game store's gameOver,
-        // so the sync plugin's watcher doesn't fire — we sync directly)
-        if (useAuth().loggedIn.value) {
-            const dayIdx = isDaily.value ? sem.dayIdx.value : undefined;
-            $fetch('/api/user/game-result', {
-                method: 'POST',
-                body: {
-                    statsKey,
+            // Analytics
+            try {
+                useAnalytics().trackGameComplete({
+                    language: langStore.languageCode,
                     won: sem.won.value,
                     attempts: sem.guesses.value.length,
-                    dayIdx,
                     game_mode: 'semantic',
                     play_type: playType.value,
-                },
-            }).catch(() => {
-                /* non-fatal — will sync on next full sync */
-            });
-        }
-
-        // Analytics
-        try {
-            useAnalytics().trackGameComplete({
-                language: langStore.languageCode,
-                won: sem.won.value,
-                attempts: sem.guesses.value.length,
-                game_mode: 'semantic',
-                play_type: playType.value,
-                is_first_game: stats.stats.n_games === 0,
-            });
-        } catch {
-            /* non-fatal */
+                    is_first_game: stats.stats.n_games === 0,
+                });
+            } catch {
+                /* non-fatal */
+            }
         }
     }
 );
@@ -714,9 +694,6 @@ function onKeepPlaying() {
 @media (max-width: 520px) {
     .semantic-body {
         padding: 8px 4px 16px;
-        /* Prevent keyboard-open scroll: input is position:fixed,
-           so the body doesn't need to scroll to show it. */
-        overflow-y: hidden;
     }
     .semantic-layout {
         gap: 8px;

--- a/pages/[lang]/speed.vue
+++ b/pages/[lang]/speed.vue
@@ -38,6 +38,11 @@ const {
     config,
 } = useGamePage(gameData, lang);
 
+// Detect day rollover when tab regains focus
+if (isDaily.value) {
+    useDayRollover(lang, gameData.value!.todays_idx);
+}
+
 // --- SEO ---
 const seo = useGameSeo({
     lang,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -726,39 +726,41 @@ function openMultiBoardPicker(): void {
             </div>
 
             <!-- ═══ Signed-in user greeting (centered, above language) ═══ -->
-            <div v-if="authLoggedIn && authUser" class="flex flex-col items-center gap-1 mb-6">
-                <NuxtLink
-                    to="/profile"
-                    class="flex items-center gap-3 hover:opacity-80 transition-opacity"
-                >
-                    <img
-                        v-if="authAvatarUrl"
-                        :src="authAvatarUrl"
-                        alt=""
-                        class="w-10 h-10 rounded-full object-cover"
-                        referrerpolicy="no-referrer"
-                    />
-                    <div
-                        v-else
-                        class="w-10 h-10 rounded-full bg-ink text-paper flex items-center justify-center heading-body text-sm"
+            <RevealTransition>
+                <div v-if="authLoggedIn && authUser" class="flex flex-col items-center gap-1 mb-6">
+                    <NuxtLink
+                        to="/profile"
+                        class="flex items-center gap-3 hover:opacity-80 transition-opacity"
                     >
-                        {{ (authUser.displayName || authUser.email || '?')[0]?.toUpperCase() }}
+                        <img
+                            v-if="authAvatarUrl"
+                            :src="authAvatarUrl"
+                            alt=""
+                            class="w-10 h-10 rounded-full object-cover"
+                            referrerpolicy="no-referrer"
+                        />
+                        <div
+                            v-else
+                            class="w-10 h-10 rounded-full bg-ink text-paper flex items-center justify-center heading-body text-sm"
+                        >
+                            {{ (authUser.displayName || authUser.email || '?')[0]?.toUpperCase() }}
+                        </div>
+                        <div class="text-sm font-semibold text-ink">
+                            {{ authUser.displayName || 'Player' }}
+                        </div>
+                    </NuxtLink>
+                    <div
+                        v-if="productStreak > 0"
+                        class="mono-label flex items-center gap-1"
+                        style="color: var(--color-flame)"
+                    >
+                        <Flame :size="12" /> {{ productStreak }} day streak
                     </div>
-                    <div class="text-sm font-semibold text-ink">
-                        {{ authUser.displayName || 'Player' }}
+                    <div v-else class="mono-label flex items-center gap-1 text-muted">
+                        <Flame :size="12" /> Play today's daily to start a streak
                     </div>
-                </NuxtLink>
-                <div
-                    v-if="productStreak > 0"
-                    class="mono-label flex items-center gap-1"
-                    style="color: var(--color-flame)"
-                >
-                    <Flame :size="12" /> {{ productStreak }} day streak
                 </div>
-                <div v-else class="mono-label flex items-center gap-1 text-muted">
-                    <Flame :size="12" /> Play today's daily to start a streak
-                </div>
-            </div>
+            </RevealTransition>
 
             <!-- ═══ Language indicator ═══ -->
             <div class="flex items-center justify-center gap-2 mb-6 px-4">
@@ -803,50 +805,58 @@ function openMultiBoardPicker(): void {
                 </div>
 
                 <!-- Continue Playing cards -->
-                <div v-if="continuePlayingCards.length > 0" class="mb-6">
-                    <div class="mono-label mb-2 px-1">Continue Playing</div>
-                    <div class="flex flex-col gap-2">
-                        <NuxtLink
-                            v-for="card in continuePlayingCards"
-                            :key="card.key"
-                            :to="card.href"
-                            class="flex items-center gap-3 px-4 py-3 border transition-colors hover:bg-paper-warm"
-                            :style="{ borderColor: card.borderColor }"
-                        >
-                            <!-- Stacked icon: mode icon with flag badge -->
-                            <div class="relative flex-shrink-0 w-10 h-10">
-                                <div
-                                    class="w-10 h-10 rounded-full border border-rule bg-paper-warm flex items-center justify-center"
-                                >
-                                    <component :is="card.modeIcon" :size="18" class="text-ink" />
+                <RevealTransition>
+                    <div v-if="continuePlayingCards.length > 0" class="mb-6">
+                        <div class="mono-label mb-2 px-1">Continue Playing</div>
+                        <div class="flex flex-col gap-2">
+                            <NuxtLink
+                                v-for="card in continuePlayingCards"
+                                :key="card.key"
+                                :to="card.href"
+                                class="flex items-center gap-3 px-4 py-3 border transition-colors hover:bg-paper-warm"
+                                :style="{ borderColor: card.borderColor }"
+                            >
+                                <!-- Stacked icon: mode icon with flag badge -->
+                                <div class="relative flex-shrink-0 w-10 h-10">
+                                    <div
+                                        class="w-10 h-10 rounded-full border border-rule bg-paper-warm flex items-center justify-center"
+                                    >
+                                        <component
+                                            :is="card.modeIcon"
+                                            :size="18"
+                                            class="text-ink"
+                                        />
+                                    </div>
+                                    <img
+                                        v-if="card.flagSrc"
+                                        :src="card.flagSrc"
+                                        :alt="card.langName"
+                                        class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full object-cover border border-paper"
+                                    />
                                 </div>
-                                <img
-                                    v-if="card.flagSrc"
-                                    :src="card.flagSrc"
-                                    :alt="card.langName"
-                                    class="absolute -bottom-1 -right-1 w-5 h-5 rounded-full object-cover border border-paper"
-                                />
-                            </div>
-                            <div class="flex-1 min-w-0">
-                                <div class="text-sm font-semibold text-ink">{{ card.title }}</div>
-                                <div class="text-xs text-muted">{{ card.subtitle }}</div>
-                            </div>
-                            <div class="flex-shrink-0 flex items-center gap-1.5">
-                                <CircleCheck
-                                    v-if="card.dailySolved"
-                                    :size="16"
-                                    class="text-correct"
-                                />
-                                <span
-                                    v-else
-                                    class="mono-label text-muted"
-                                    style="font-size: 10px"
-                                    >{{ card.cta }}</span
-                                >
-                            </div>
-                        </NuxtLink>
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-sm font-semibold text-ink">
+                                        {{ card.title }}
+                                    </div>
+                                    <div class="text-xs text-muted">{{ card.subtitle }}</div>
+                                </div>
+                                <div class="flex-shrink-0 flex items-center gap-1.5">
+                                    <CircleCheck
+                                        v-if="card.dailySolved"
+                                        :size="16"
+                                        class="text-correct"
+                                    />
+                                    <span
+                                        v-else
+                                        class="mono-label text-muted"
+                                        style="font-size: 10px"
+                                        >{{ card.cta }}</span
+                                    >
+                                </div>
+                            </NuxtLink>
+                        </div>
                     </div>
-                </div>
+                </RevealTransition>
 
                 <!-- Sign-in CTA (Tier 1 only) -->
                 <button
@@ -1034,7 +1044,7 @@ function openMultiBoardPicker(): void {
             <!-- ═══ Modals ═══ -->
 
             <!-- About modal -->
-            <SharedBaseModal :visible="showAboutModal" size="sm" @close="showAboutModal = false">
+            <BaseModal :visible="showAboutModal" size="sm" @close="showAboutModal = false">
                 <div class="flex flex-col gap-3">
                     <h3 class="heading-section text-xl text-center mb-2">About</h3>
                     <p class="text-center text-sm text-ink">
@@ -1055,7 +1065,7 @@ function openMultiBoardPicker(): void {
                     </p>
                     <p class="text-center text-sm text-ink">Have fun!</p>
                 </div>
-            </SharedBaseModal>
+            </BaseModal>
 
             <!-- Game Mode Picker modal -->
             <AppGameModePicker

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -211,7 +211,7 @@ const productBestStreak = computed(() => productBestStreakRaw.value);
 const animProductStreak = useAnimatedNumber(productStreak);
 const streakExpanded = ref(false);
 
-// Calendar heatmap uses SharedStreakCalendar component (DRY with StreakModal)
+// Calendar heatmap uses StreakCalendar component (DRY with StreakModal)
 
 // Classic daily (from store's calculateTotalStats)
 const totalGames = ref(0);
@@ -235,7 +235,7 @@ const modeStats = ref<ModeStats[]>([]);
 const speedAggregate = ref<SpeedAggregate | null>(null);
 
 // Tab state for the stats section
-type StatsTab = 'overview' | 'distribution' | 'languages' | 'speed';
+type StatsTab = 'overview' | 'distribution' | 'languages';
 const activeTab = ref<StatsTab>('overview');
 const availableTabs = computed<{ id: StatsTab; label: string }[]>(() => {
     const tabs: { id: StatsTab; label: string }[] = [{ id: 'overview', label: 'Overview' }];
@@ -246,9 +246,7 @@ const availableTabs = computed<{ id: StatsTab; label: string }[]>(() => {
     if (perLang.value.length > 0) {
         tabs.push({ id: 'languages', label: `Languages (${perLang.value.length})` });
     }
-    if (speedAggregate.value && speedAggregate.value.games > 0) {
-        tabs.push({ id: 'speed', label: 'Speed' });
-    }
+    // Speed stats are shown inline in the overview — no separate tab needed
     return tabs;
 });
 
@@ -470,90 +468,96 @@ const languagesConquered = computed(() => {
             </header>
 
             <!-- Profile section -->
-            <section v-if="authLoggedIn" class="mb-10">
-                <div class="flex items-center gap-4">
-                    <img
-                        v-if="authUser?.avatarUrl"
-                        :src="authUser.avatarUrl"
-                        alt=""
-                        class="w-16 h-16 rounded-full object-cover flex-shrink-0"
-                        referrerpolicy="no-referrer"
-                    />
-                    <div
-                        v-else
-                        class="w-16 h-16 rounded-full bg-ink text-paper flex items-center justify-center text-xl font-display font-bold flex-shrink-0"
-                    >
-                        {{ (authUser?.displayName ?? 'P')[0] }}
-                    </div>
-                    <div class="flex-1 min-w-0">
-                        <!-- Editable display name -->
-                        <div v-if="editingName" class="flex items-center gap-2">
-                            <input
-                                ref="nameInputRef"
-                                v-model="editName"
-                                type="text"
-                                maxlength="50"
-                                class="heading-section text-xl text-ink bg-transparent border-b border-ink focus:outline-none w-full"
-                                @keydown.enter="saveName()"
-                                @keydown.escape="editingName = false"
-                            />
-                            <button
-                                class="text-sm text-correct hover:underline flex-shrink-0"
-                                @click="saveName()"
-                            >
-                                Save
-                            </button>
-                            <button
-                                class="text-sm text-muted hover:underline flex-shrink-0"
-                                @click="editingName = false"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                        <h2
+            <RevealTransition>
+                <section v-if="authLoggedIn" class="mb-10">
+                    <div class="flex items-center gap-4">
+                        <img
+                            v-if="authUser?.avatarUrl"
+                            :src="authUser.avatarUrl"
+                            alt=""
+                            class="w-16 h-16 rounded-full object-cover flex-shrink-0"
+                            referrerpolicy="no-referrer"
+                        />
+                        <div
                             v-else
-                            class="heading-section text-xl text-ink cursor-pointer hover:opacity-70 transition-opacity"
-                            title="Click to edit name"
-                            @click="startEditName()"
+                            class="w-16 h-16 rounded-full bg-ink text-paper flex items-center justify-center text-xl font-display font-bold flex-shrink-0"
                         >
-                            {{ authUser?.displayName ?? 'Player' }}
-                            <Pencil :size="12" class="inline text-muted ml-1" />
-                        </h2>
-                        <div v-if="authUser?.email" class="mono-label">{{ authUser.email }}</div>
-                        <div v-if="profileData?.createdAt" class="mono-label mt-0.5">
-                            Member since {{ formatDate(profileData.createdAt) }}
+                            {{ (authUser?.displayName ?? 'P')[0] }}
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <!-- Editable display name -->
+                            <div v-if="editingName" class="flex items-center gap-2">
+                                <input
+                                    ref="nameInputRef"
+                                    v-model="editName"
+                                    type="text"
+                                    maxlength="50"
+                                    class="heading-section text-xl text-ink bg-transparent border-b border-ink focus:outline-none w-full"
+                                    @keydown.enter="saveName()"
+                                    @keydown.escape="editingName = false"
+                                />
+                                <button
+                                    class="text-sm text-correct hover:underline flex-shrink-0"
+                                    @click="saveName()"
+                                >
+                                    Save
+                                </button>
+                                <button
+                                    class="text-sm text-muted hover:underline flex-shrink-0"
+                                    @click="editingName = false"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                            <h2
+                                v-else
+                                class="heading-section text-xl text-ink cursor-pointer hover:opacity-70 transition-opacity"
+                                title="Click to edit name"
+                                @click="startEditName()"
+                            >
+                                {{ authUser?.displayName ?? 'Player' }}
+                                <Pencil :size="12" class="inline text-muted ml-1" />
+                            </h2>
+                            <div v-if="authUser?.email" class="mono-label">
+                                {{ authUser.email }}
+                            </div>
+                            <div v-if="profileData?.createdAt" class="mono-label mt-0.5">
+                                Member since {{ formatDate(profileData.createdAt) }}
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                <!-- Account actions -->
-                <div class="mt-6 flex items-center gap-4">
-                    <button
-                        class="text-sm text-muted hover:text-ink transition-colors flex items-center gap-1"
-                        @click="authLogout()"
-                    >
-                        <LogOut :size="14" />
-                        Sign out
-                    </button>
-                </div>
-            </section>
+                    <!-- Account actions -->
+                    <div class="mt-6 flex items-center gap-4">
+                        <button
+                            class="text-sm text-muted hover:text-ink transition-colors flex items-center gap-1"
+                            @click="authLogout()"
+                        >
+                            <LogOut :size="14" />
+                            Sign out
+                        </button>
+                    </div>
+                </section>
+            </RevealTransition>
 
             <!-- Sign-in CTA (logged out) — reuses the login modal -->
-            <section
-                v-if="!authLoggedIn && !empty"
-                class="mb-10 border border-rule p-5 text-center"
-            >
-                <h2 class="heading-body text-lg text-ink mb-2">Save your progress</h2>
-                <p class="text-sm text-muted mb-4">
-                    Sign in to sync stats across devices, earn badges, and protect your streak.
-                </p>
-                <button
-                    class="px-6 py-2 bg-ink text-paper text-sm font-semibold hover:opacity-90 transition-opacity"
-                    @click="openLoginModal()"
+            <RevealTransition>
+                <section
+                    v-if="!authLoggedIn && !empty"
+                    class="mb-10 border border-rule p-5 text-center"
                 >
-                    Sign in
-                </button>
-            </section>
+                    <h2 class="heading-body text-lg text-ink mb-2">Save your progress</h2>
+                    <p class="text-sm text-muted mb-4">
+                        Sign in to sync stats across devices, earn badges, and protect your streak.
+                    </p>
+                    <button
+                        class="px-6 py-2 bg-ink text-paper text-sm font-semibold hover:opacity-90 transition-opacity"
+                        @click="openLoginModal()"
+                    >
+                        Sign in
+                    </button>
+                </section>
+            </RevealTransition>
 
             <!-- Empty state -->
             <div v-if="empty" class="text-center py-16">
@@ -600,7 +604,7 @@ const languagesConquered = computed(() => {
                         class="mt-5 pt-4 border-t border-rule text-left"
                         @click.stop
                     >
-                        <SharedStreakCalendar
+                        <StreakCalendar
                             :game-results="statsStore.gameResults as Record<string, GameResult[]>"
                         />
                         <!-- Current / Longest row -->
@@ -717,7 +721,10 @@ const languagesConquered = computed(() => {
                         </div>
                         <!-- Per-mode breakdown -->
                         <div
-                            v-if="sortedModes.length > 0"
+                            v-if="
+                                sortedModes.length > 0 ||
+                                (speedAggregate && speedAggregate.games > 0)
+                            "
                             class="border border-t-0 border-rule divide-y divide-rule"
                         >
                             <div
@@ -727,29 +734,39 @@ const languagesConquered = computed(() => {
                                 style="padding: 10px 16px"
                             >
                                 <component :is="m.icon" :size="16" class="text-ink flex-shrink-0" />
-                                <span class="text-sm font-medium text-ink flex-1">{{
-                                    m.label
-                                }}</span>
-                                <span class="text-xs text-muted tabular-nums">{{ m.games }}</span>
+                                <div class="flex-1 min-w-0">
+                                    <span class="text-sm font-medium text-ink">{{ m.label }}</span>
+                                    <span class="text-xs text-muted ml-1">
+                                        {{ m.games }} played
+                                        <template v-if="m.avgAttempts !== '-'">
+                                            · avg {{ m.avgAttempts }}
+                                        </template>
+                                    </span>
+                                </div>
                                 <span
-                                    class="text-xs tabular-nums w-10 text-right"
+                                    class="text-xs font-semibold tabular-nums"
                                     :class="m.winPct >= 50 ? 'text-correct' : 'text-muted'"
                                     >{{ m.winPct }}%</span
                                 >
                             </div>
+                            <!-- Speed Streak (inline, not separate tab) -->
                             <div
                                 v-if="speedAggregate && speedAggregate.games > 0"
                                 class="flex items-center gap-3"
                                 style="padding: 10px 16px"
                             >
                                 <Zap :size="16" class="text-ink flex-shrink-0" />
-                                <span class="text-sm font-medium text-ink flex-1"
-                                    >Speed Streak</span
-                                >
-                                <span class="text-xs text-muted tabular-nums">{{
-                                    speedAggregate.games
-                                }}</span>
-                                <span class="text-xs text-muted w-10 text-right">—</span>
+                                <div class="flex-1 min-w-0">
+                                    <span class="text-sm font-medium text-ink">Speed Streak</span>
+                                    <span class="text-xs text-muted ml-1">
+                                        {{ speedAggregate.games }} sessions · best
+                                        {{ speedAggregate.bestScore.toLocaleString() }} pts ·
+                                        {{ speedAggregate.bestWordsSolved }} words
+                                    </span>
+                                </div>
+                                <span class="text-xs font-semibold text-correct tabular-nums">
+                                    {{ speedAggregate.bestMaxCombo }}x
+                                </span>
                             </div>
                         </div>
                     </div>
@@ -839,101 +856,32 @@ const languagesConquered = computed(() => {
                         </div>
                     </div>
 
-                    <!-- Tab: Speed -->
-                    <div v-if="speedAggregate" v-show="activeTab === 'speed'">
-                        <div
-                            class="grid grid-cols-4 border border-rule"
-                            style="background: var(--color-rule); gap: 1px"
-                        >
-                            <div class="bg-paper text-center" style="padding: 14px 8px">
-                                <div
-                                    class="font-display font-bold text-ink"
-                                    style="font-size: 22px; font-variation-settings: 'opsz' 72"
-                                >
-                                    {{ speedAggregate.games }}
-                                </div>
-                                <div class="mono-label mt-0.5">Sessions</div>
-                            </div>
-                            <div class="bg-paper text-center" style="padding: 14px 8px">
-                                <div
-                                    class="font-display font-bold text-correct"
-                                    style="font-size: 22px; font-variation-settings: 'opsz' 72"
-                                >
-                                    {{ speedAggregate.bestScore.toLocaleString() }}
-                                </div>
-                                <div class="mono-label mt-0.5">Top Score</div>
-                            </div>
-                            <div class="bg-paper text-center" style="padding: 14px 8px">
-                                <div
-                                    class="font-display font-bold text-ink"
-                                    style="font-size: 22px; font-variation-settings: 'opsz' 72"
-                                >
-                                    {{ speedAggregate.bestWordsSolved }}
-                                </div>
-                                <div class="mono-label mt-0.5">Best Solved</div>
-                            </div>
-                            <div class="bg-paper text-center" style="padding: 14px 8px">
-                                <div
-                                    class="font-display font-bold text-ink"
-                                    style="font-size: 22px; font-variation-settings: 'opsz' 72"
-                                >
-                                    {{ speedAggregate.bestMaxCombo }}x
-                                </div>
-                                <div class="mono-label mt-0.5">Best Combo</div>
-                            </div>
-                        </div>
-                        <!-- Top 3 runs -->
-                        <div
-                            v-if="speedAggregate.topRuns.length > 0"
-                            class="border border-t-0 border-rule divide-y divide-rule"
-                        >
-                            <div
-                                v-for="(run, i) in speedAggregate.topRuns"
-                                :key="`${run.date}-${i}`"
-                                class="flex items-center gap-3"
-                                style="padding: 10px 16px"
-                            >
-                                <span
-                                    class="w-6 h-6 flex items-center justify-center border border-rule bg-paper-warm font-display font-bold text-xs text-ink flex-shrink-0"
-                                    >{{ i + 1 }}</span
-                                >
-                                <div class="flex-1 min-w-0">
-                                    <div class="text-sm font-semibold text-ink tabular-nums">
-                                        {{ run.score.toLocaleString() }} pts
-                                    </div>
-                                    <div class="text-xs text-muted tabular-nums">
-                                        {{ run.wordsSolved }} solved · {{ run.maxCombo }}x combo
-                                    </div>
-                                </div>
-                                <span class="mono-label">{{
-                                    new Date(run.date).toLocaleDateString()
-                                }}</span>
-                            </div>
-                        </div>
-                    </div>
+                    <!-- Speed stats are shown inline in the overview -->
                 </section>
 
                 <!-- ═══ Badges (collapsed by default, earned first) ═══ -->
-                <section
-                    v-if="allBadges.length > 0 && authLoggedIn"
-                    id="badges"
-                    class="mb-10 scroll-mt-16"
-                >
-                    <div
-                        class="font-display text-xl font-bold text-ink mb-1"
-                        style="font-variation-settings: 'opsz' 48"
+                <RevealTransition>
+                    <section
+                        v-if="allBadges.length > 0 && authLoggedIn"
+                        id="badges"
+                        class="mb-10 scroll-mt-16"
                     >
-                        Achievement Badges
-                    </div>
-                    <div class="text-xs text-muted mb-4">
-                        {{ earnedSlugs.size }} of {{ allBadges.length }} earned
-                    </div>
-                    <AccountBadgeGrid
-                        :badges="allBadges"
-                        :earned-slugs="earnedSlugs"
-                        :progress="badgeProgress"
-                    />
-                </section>
+                        <div
+                            class="font-display text-xl font-bold text-ink mb-1"
+                            style="font-variation-settings: 'opsz' 48"
+                        >
+                            Achievement Badges
+                        </div>
+                        <div class="text-xs text-muted mb-4">
+                            {{ earnedSlugs.size }} of {{ allBadges.length }} earned
+                        </div>
+                        <AccountBadgeGrid
+                            :badges="allBadges"
+                            :earned-slugs="earnedSlugs"
+                            :progress="badgeProgress"
+                        />
+                    </section>
+                </RevealTransition>
 
                 <!-- CTA -->
                 <div class="text-center">

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -827,11 +827,10 @@ const languagesConquered = computed(() => {
                     <!-- Tab: Languages -->
                     <div v-show="activeTab === 'languages'">
                         <div class="border border-rule divide-y divide-rule">
-                            <NuxtLink
+                            <div
                                 v-for="l in perLang"
                                 :key="l.code"
-                                :to="`/${l.code}`"
-                                class="flex items-center gap-3 hover:bg-paper-warm transition-colors"
+                                class="flex items-center gap-3"
                                 style="padding: 10px 16px"
                             >
                                 <img
@@ -847,12 +846,11 @@ const languagesConquered = computed(() => {
                                 </div>
                                 <span class="text-xs text-muted tabular-nums">{{ l.games }}</span>
                                 <span
-                                    class="text-xs tabular-nums"
+                                    class="text-xs font-semibold tabular-nums"
                                     :class="l.winPct >= 50 ? 'text-correct' : 'text-muted'"
                                     >{{ l.winPct }}%</span
                                 >
-                                <ChevronRight :size="14" class="text-muted flex-shrink-0" />
-                            </NuxtLink>
+                            </div>
                         </div>
                     </div>
 

--- a/stores/game.ts
+++ b/stores/game.ts
@@ -1885,6 +1885,9 @@ export const useGameStore = defineStore('game', () => {
             emojiBoard.value = data.emoji_board || '';
             attempts.value = data.attempts || '0';
 
+            // Render restored tiles (same as classic's loadFromLocalStorage + showTiles)
+            showTilesAllBoards();
+
             // Load definitions for completed multi-board games on restore
             if (data.game_over) {
                 loadDefinitionsForBoards();


### PR DESCRIPTION
## Summary

- **Fix: chart button opens wrong modal for semantic** — PageShell now emits `@results` for `noKeyboard` modes instead of opening the generic `GameStatsModal`. Semantic page opens its own `SemanticStatsModal`. Generic modal suppressed with `v-if="!noKeyboard"`.
- **Remove win overlay + green border** — "Found bread" badge and green `map-card.won` border removed. These were inconsistent with other modes (which use notification toasts). ~70 lines of dead CSS removed.
- **Remove unused code** — `rankColor` function, `celebrate-fade` transitions, `win-overlay`/`win-badge` styles
- **Mobile header spacing** — `px-1.5` on mobile (→ `px-3` at `sm`) gives more room for title text

## Test plan
- [ ] Semantic: chart button in header opens SemanticStatsModal (not generic)
- [ ] Semantic: no green border on map when won
- [ ] Semantic: no "Found bread" overlay badge on map
- [ ] Classic/dordle/etc: chart button still opens generic StatsModal normally
- [ ] Mobile: header icons slightly closer to edges, title less cramped

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted header padding on smallest screens; added a new “reveal” transition animation and reveal wrapper for subtle entry animations.

* **Refactor**
  * Removed win-state visual flair and map-card win styling.
  * Results handling now differs by mode: non-keyboard modes emit page events instead of auto-toggling the stats modal.

* **New Features**
  * Centralized game lifecycle for consistent save/sync; day-rollover detection reloads when a new day is available.
  * Multi-board daily games attempt local restore and immediately render restored tiles.

* **Bug Fixes**
  * Prevented mobile input scroll jump when the virtual keyboard opens.
  * Streamlined share action to show inline “Copied!” feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->