### PR TITLE
hotfix: PWA service worker blocks OAuth login

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -189,14 +189,15 @@ export default defineNuxtConfig({
         },
         workbox: {
             // Cache versioning: changing this name will invalidate old caches
-            cacheId: 'wordle-v7',
+            cacheId: 'wordle-v8',
 
             // Pre-cache essential offline assets
             globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
 
-            // Navigation fallback for offline
+            // Navigation fallback for offline — only game pages, not auth/API routes
             navigateFallback: '/offline.html',
             navigateFallbackAllowlist: [/^\/[a-z]{2,3}(\/|$)/],
+            navigateFallbackDenylist: [/^\/auth\//, /^\/api\//],
 
             // Clean up old caches from previous versions
             cleanupOutdatedCaches: true,
@@ -208,10 +209,10 @@ export default defineNuxtConfig({
             // Runtime caching strategies
             runtimeCaching: [
                 {
-                    // HTML pages and API routes: NetworkFirst
-                    // Pages contain the daily word which changes, so always try network
+                    // HTML pages and API routes: NetworkFirst (exclude auth — must hit server)
                     urlPattern: ({ request, url }) =>
-                        request.mode === 'navigate' || url.pathname.startsWith('/api/'),
+                        (request.mode === 'navigate' && !url.pathname.startsWith('/auth/')) ||
+                        url.pathname.startsWith('/api/'),
                     handler: 'NetworkFirst',
                     options: {
                         cacheName: 'wordle-pages',

--- a/plugins/server-route-guard.client.ts
+++ b/plugins/server-route-guard.client.ts
@@ -1,0 +1,20 @@
+/**
+ * Server Route Guard (client-only)
+ *
+ * Safety net for stale service workers or PWA caches that accidentally
+ * serve the SPA shell for server-only routes (/auth/*, /api/*).
+ * Forces a full page navigation to the server instead of a 404 in the
+ * client-side Vue router.
+ */
+export default defineNuxtPlugin(() => {
+    const router = useRouter();
+
+    router.beforeEach((to) => {
+        const path = to.fullPath;
+        if (path.startsWith('/auth/') || path.startsWith('/api/')) {
+            // Force full server navigation — bypass the SPA router
+            window.location.href = path;
+            return false;
+        }
+    });
+});


### PR DESCRIPTION
## Problem
Google OAuth login returns 500 in PWA (installed app). The service worker intercepts the OAuth callback navigation (`/auth/google?code=...`) and serves the cached SPA shell. Vue Router has no page at `/auth/google` → "Page Not Found".

## Fix
- `navigateFallbackDenylist`: excludes `/auth/` and `/api/` from offline fallback
- Runtime cache `urlPattern`: excludes `/auth/` navigations from NetworkFirst caching
- Cache version bumped `v7→v8` to purge stale entries on existing PWA installs

## Test
- Install PWA on phone → sign in with Google → should complete without 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PWA cache versioning to clear previously stored cache data.
  * Refined offline page fallback behavior for authentication and API routes, ensuring these critical paths maintain direct server communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->