### PR TITLE
fix: language picker, game mode close button, sidebar UX

### DIFF
--- a/components/app/AppShell.vue
+++ b/components/app/AppShell.vue
@@ -46,6 +46,13 @@
 
         <!-- Streak modal — available on all pages -->
         <GameStreakModal :visible="showStreakModal" @close="showStreakModal = false" />
+
+        <!-- Language picker modal — consistent with game pages -->
+        <LanguagePickerModal
+            :visible="showLanguageModal"
+            :current-lang="lang"
+            @close="showLanguageModal = false"
+        />
     </div>
 </template>
 
@@ -79,6 +86,7 @@ const props = withDefaults(
 const sidebarOpen = ref(false);
 const showSettings = ref(false);
 const showStreakModal = ref(false);
+const showLanguageModal = ref(false);
 
 // Product-wide streak — single source via composable (client-only, returns 0 during SSR)
 const { streak: streakCount } = useProductStreak();
@@ -93,7 +101,7 @@ function onSelectMode(mode: string) {
 
 function onSelectLanguage() {
     sidebarOpen.value = false;
-    navigateTo('/#languages');
+    showLanguageModal.value = true;
 }
 </script>
 

--- a/components/app/AppShell.vue
+++ b/components/app/AppShell.vue
@@ -48,9 +48,9 @@
         <GameStreakModal :visible="showStreakModal" @close="showStreakModal = false" />
 
         <!-- Language picker modal — consistent with game pages -->
-        <LanguagePickerModal
+        <AppLanguagePickerModal
             :visible="showLanguageModal"
-            :current-lang="lang"
+            :current-lang-code="lang"
             @close="showLanguageModal = false"
         />
     </div>

--- a/components/app/GameModePicker.vue
+++ b/components/app/GameModePicker.vue
@@ -4,7 +4,6 @@
         size="lg"
         align="top"
         no-padding
-        no-close-button
         :aria-label="`Choose a game mode for ${languageName}`"
         @close="$emit('close')"
     >

--- a/components/app/LanguagePickerModal.vue
+++ b/components/app/LanguagePickerModal.vue
@@ -57,23 +57,23 @@
 import { ref, computed, watch, nextTick } from 'vue';
 import { useFlag } from '~/composables/useFlag';
 
-const props = defineProps<{
-    visible: boolean;
-    currentLangCode: string;
-    /** All available language codes */
-    languageCodes: string[];
-    /** Language name map: code → { name, nativeName } */
-    languageNames?: Record<string, { name: string; nativeName?: string }>;
-    /** Current mode route suffix (e.g., 'dordle', 'semantic', '') */
-    currentModeSuffix?: string;
-    /** Current play type query */
-    currentPlayType?: string;
-}>();
+const props = withDefaults(
+    defineProps<{
+        visible: boolean;
+        currentLangCode: string;
+        /** Current mode route suffix (e.g., 'dordle', 'semantic', ''). Used to try same mode in new language. */
+        currentModeSuffix?: string;
+    }>(),
+    { currentModeSuffix: '' }
+);
 
 const emit = defineEmits<{ close: [] }>();
 
 const searchRef = ref<HTMLInputElement | null>(null);
 const searchQuery = ref('');
+
+// Fetch language data once (cached by Nuxt)
+const { data: langData } = useFetch('/api/languages', { key: 'languages-picker' });
 
 // Auto-focus search on open
 watch(
@@ -87,17 +87,19 @@ watch(
     }
 );
 
-const languages = computed(() =>
-    props.languageCodes.map((code) => {
-        const names = props.languageNames?.[code];
+const languages = computed(() => {
+    const codes = langData.value?.language_codes ?? [];
+    const names = langData.value?.languages ?? {};
+    return codes.map((code: string) => {
+        const info = names[code];
         return {
             code,
-            name: names?.name || code,
-            nativeName: names?.nativeName || names?.name || code,
+            name: info?.language_name || code,
+            nativeName: info?.language_name_native || info?.language_name || code,
             flagSrc: useFlag(code),
         };
-    })
-);
+    });
+});
 
 const filteredLanguages = computed(() => {
     const q = searchQuery.value.toLowerCase().trim();
@@ -112,8 +114,13 @@ const filteredLanguages = computed(() => {
 
 function selectLanguage(code: string) {
     emit('close');
-    const suffix = props.currentModeSuffix ? `/${props.currentModeSuffix}` : '';
-    const playParam = props.currentPlayType === 'unlimited' ? '?play=unlimited' : '';
-    navigateTo(`/${code}${suffix}${playParam}`);
+    // Try to stay in the same game mode in the new language.
+    // Modes that are language-restricted (e.g., semantic = English-only)
+    // have server-side redirects that will send the user to the right place.
+    if (props.currentModeSuffix) {
+        navigateTo(`/${code}/${props.currentModeSuffix}`);
+    } else {
+        navigateTo(`/${code}`);
+    }
 }
 </script>

--- a/components/game/PageShell.vue
+++ b/components/game/PageShell.vue
@@ -17,7 +17,10 @@
                         navigateTo(`/${lang}/${mode === 'classic' ? '' : mode + '/'}`);
                     }
                 "
-                @select-language="showLanguageModal = true"
+                @select-language="
+                    $emit('closeSidebar');
+                    showLanguageModal = true;
+                "
                 @settings="game.showOptionsModal = !game.showOptionsModal"
             />
 

--- a/components/game/PageShell.vue
+++ b/components/game/PageShell.vue
@@ -107,13 +107,11 @@
                 <AppLanguagePickerModal
                     :visible="showLanguageModal"
                     :current-lang-code="lang"
-                    :language-codes="allLangCodes"
                     :current-mode-suffix="
                         game.gameConfig.mode === 'classic'
                             ? ''
                             : GAME_MODE_CONFIG[game.gameConfig.mode]?.routeSuffix || ''
                     "
-                    :current-play-type="game.gameConfig.playType"
                     @close="showLanguageModal = false"
                 />
 
@@ -195,8 +193,6 @@ function openWithSubPanel() {
 
 // Language picker modal state
 const showLanguageModal = ref(false);
-const { data: langData } = useFetch('/api/languages', { key: 'languages' });
-const allLangCodes = computed(() => langData.value?.language_codes ?? []);
 const langStore = useLanguageStore();
 const analytics = useAnalytics();
 const gameKeyboardRef = ref<{ $el: HTMLElement } | null>(null);

--- a/components/semantic/SemanticInput.vue
+++ b/components/semantic/SemanticInput.vue
@@ -6,7 +6,7 @@
 -->
 
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue';
+import { nextTick, onUnmounted, ref, watch } from 'vue';
 
 const props = defineProps<{
     loading: boolean;
@@ -48,23 +48,24 @@ watch(
     { immediate: true }
 );
 
-// On mobile, the virtual keyboard opens and the browser scrolls the nearest
-// scrollable ancestor to keep the input visible. But the input is position:fixed
-// on mobile — it doesn't need scrolling. Lock scroll position on focus, restore on blur.
-let savedScrollTop = 0;
+// On mobile, the virtual keyboard triggers a document-level scroll that
+// can snap the page to the SEO section below the game viewport, making
+// the header unreachable. The input is position:fixed on mobile so the
+// browser doesn't need to scroll. Lock document scroll on focus to prevent
+// this — the semantic body's internal scroll still works (own overflow context).
 function onFocus() {
     if (!isTouch) return;
-    const scrollable = inputRef.value?.closest('.semantic-body') as HTMLElement | null;
-    if (scrollable) {
-        savedScrollTop = scrollable.scrollTop;
-        requestAnimationFrame(() => {
-            scrollable.scrollTop = savedScrollTop;
-        });
-    }
+    document.documentElement.style.overflow = 'hidden';
 }
 function onBlur() {
-    // No action needed — scroll is already at the saved position
+    if (!isTouch) return;
+    document.documentElement.style.overflow = '';
 }
+
+// Cleanup: ensure scroll is unlocked if component unmounts while focused
+onUnmounted(() => {
+    document.documentElement.style.overflow = '';
+});
 
 defineExpose({
     focus: () => inputRef.value?.focus(),

--- a/components/semantic/SemanticLeaderboard.vue
+++ b/components/semantic/SemanticLeaderboard.vue
@@ -232,6 +232,12 @@ function onRowLeave() {
         opacity: 1;
     }
 }
+/* Hide the verbose empty-state CTA on mobile — input field is self-explanatory */
+@media (max-width: 520px) {
+    .leaderboard-header.empty-cta {
+        display: none;
+    }
+}
 
 .mono-label {
     font-family: var(--font-mono);

--- a/composables/useGamePage.ts
+++ b/composables/useGamePage.ts
@@ -73,6 +73,8 @@ export function useGamePage(gameData: Ref<GameData | null>, lang: string) {
 
     // --- Lifecycle ---
     onMounted(() => {
+        game.gameActive = true;
+
         // Pass board DOM ref to game store for animations
         // (keyboard ref is wired by GamePageShell)
         game.setBoardEl(() => gameBoardRef.value?.boardEl ?? null);
@@ -80,6 +82,7 @@ export function useGamePage(gameData: Ref<GameData | null>, lang: string) {
         // Keyboard event listener
         window.addEventListener('keydown', handleKeyDown);
         onUnmounted(() => {
+            game.gameActive = false;
             window.removeEventListener('keydown', handleKeyDown);
         });
 

--- a/composables/useSemanticGame.ts
+++ b/composables/useSemanticGame.ts
@@ -225,6 +225,7 @@ export function useSemanticGame(lang: string) {
     async function startGame(
         opts: { target?: string; debug?: boolean; forceNew?: boolean; play?: string } = {}
     ) {
+        if (starting.value) return; // Guard against overlapping calls
         starting.value = true;
         invalidMessage.value = '';
         mapMode.value = 'umap';

--- a/composables/useSemanticGame.ts
+++ b/composables/useSemanticGame.ts
@@ -124,12 +124,13 @@ type SavedSemanticState = {
     neighbours: Neighbour[];
 };
 
-function storageKey(lang: string): string {
-    return `semantic_game_${lang}`;
+function storageKey(lang: string, play?: string): string {
+    return play === 'unlimited' ? `semantic_game_${lang}_unlimited` : `semantic_game_${lang}`;
 }
 
 export function useSemanticGame(lang: string) {
     // ── Session / meta ────────────────────────────────────────────────────
+    let _currentPlay: string = 'daily'; // tracks daily vs unlimited for storage key
     const targetId = ref<string | null>(null);
     const dayIdx = ref<number>(0);
     const axisAnchors = ref<Record<string, { low: string; high: string }>>({});
@@ -229,6 +230,7 @@ export function useSemanticGame(lang: string) {
         mapMode.value = 'umap';
         sliceAxes.value = null;
         newBestSignal.value = null;
+        _currentPlay = opts.play ?? 'daily';
 
         try {
             const resp = await $fetch<StartResponse>(`/api/${lang}/semantic/start`, {
@@ -264,7 +266,7 @@ export function useSemanticGame(lang: string) {
             llmHint.value = null;
             llmHintUsed.value = false;
             _prevBestRank = null;
-            removeLocal(storageKey(lang));
+            removeLocal(storageKey(lang, _currentPlay));
         } catch (e) {
             console.warn('[semantic-game] start failed', e);
             invalidMessage.value = 'Could not start game. Retry?';
@@ -434,13 +436,13 @@ export function useSemanticGame(lang: string) {
             finalTargetWord: finalTargetWord.value,
             neighbours: neighbours.value,
         };
-        writeJson(storageKey(lang), state);
+        writeJson(storageKey(lang, _currentPlay), state);
     }
 
     /** Try to restore saved state for the current day. Returns true if
      *  state was successfully restored, false if no matching save exists. */
     function restoreState(currentDayIdx: number): boolean {
-        const saved = readJson<SavedSemanticState>(storageKey(lang));
+        const saved = readJson<SavedSemanticState>(storageKey(lang, _currentPlay));
         if (!saved || saved.dayIdx !== currentDayIdx) return false;
         if (!saved.guesses?.length) return false;
 

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -27,9 +27,9 @@ const route = useRoute();
 const lang = route.params.lang as string;
 
 // Semantic Explorer is English-only for v1. Redirect other languages
-// so crawlers and direct-link visitors don't see a broken game.
+// to their classic daily page instead of forcing them into English semantic.
 if (lang !== 'en') {
-    await navigateTo(`/en/semantic`, { redirectCode: 302 });
+    await navigateTo(`/${lang}`, { redirectCode: 302 });
 }
 
 // Play type: daily (default) or unlimited via ?play=unlimited

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -698,15 +698,14 @@ function onKeepPlaying() {
     }
     .map-card {
         padding: 10px 10px 10px;
-        border-left: none;
-        border-right: none;
+        border: none;
     }
-    .map-header {
-        margin-bottom: 8px;
+    /* Hide expand button on mobile — map is already near-fullscreen */
+    :deep([aria-label='Expand map']),
+    :deep([aria-label='Collapse map']) {
+        display: none;
     }
-    /* Hide the entire map header on mobile — redundant with the app
-       header which already shows "Semantic #99" + guesses remaining
-       is shown in the input meta row. Saves ~60px of vertical space. */
+    /* Hide map header on mobile — redundant with app header */
     .map-header {
         display: none;
     }

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -400,7 +400,7 @@ function onKeepPlaying() {
             </p>
             <button
                 class="px-6 py-2 bg-accent text-paper font-body font-bold hover:opacity-90 transition-opacity"
-                @click="sem.startGame()"
+                @click="sem.startGame({ play: playType })"
             >
                 Retry
             </button>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -8,14 +8,25 @@
  */
 import { readJson } from '~/utils/storage';
 import { useAnimatedNumber } from '~/composables/useAnimatedNumber';
-import { BarChart2, Flame, Square, Zap, ChevronRight } from 'lucide-vue-next';
+import { BarChart2, Flame, Square, Zap, ChevronRight, Download } from 'lucide-vue-next';
 import { isClassicDailyStatsKey, GAME_MODE_CONFIG, GAME_MODE_ORDER } from '~/utils/game-modes';
 import type { GameMode } from '~/utils/game-modes';
 import type { SpeedAggregate } from '~/utils/types';
 import { createEmptyDistribution } from '~/utils/types';
 
 import { useFlag } from '~/composables/useFlag';
+import { isStandalone } from '~/utils/storage';
 import type { GameResult } from '~/utils/types';
+
+// PWA install — show "Install App" CTA if not already installed
+const pwaInstall = import.meta.client
+    ? inject<{ install: () => void; status: () => { isStandalone: boolean } }>('pwaInstall', undefined)
+    : undefined;
+const showInstallCta = computed(() => {
+    if (!import.meta.client) return false;
+    if (isStandalone()) return false;
+    return !!pwaInstall;
+});
 
 useSeoMeta({
     title: 'Your Profile — Wordle Global',
@@ -881,14 +892,25 @@ const languagesConquered = computed(() => {
                     </section>
                 </RevealTransition>
 
-                <!-- CTA -->
+                <!-- CTA: Install App (if not PWA) or Play Wordle -->
                 <div class="text-center">
-                    <NuxtLink
-                        to="/"
-                        class="inline-block py-3 px-8 bg-ink text-paper font-body text-sm font-semibold tracking-wide transition-opacity hover:opacity-85"
-                    >
-                        Play Wordle
-                    </NuxtLink>
+                    <ClientOnly>
+                        <button
+                            v-if="showInstallCta"
+                            class="inline-flex items-center gap-2 py-3 px-8 bg-ink text-paper font-body text-sm font-semibold tracking-wide transition-opacity hover:opacity-85"
+                            @click="pwaInstall?.install()"
+                        >
+                            <Download :size="16" />
+                            Install App
+                        </button>
+                        <NuxtLink
+                            v-else
+                            to="/"
+                            class="inline-block py-3 px-8 bg-ink text-paper font-body text-sm font-semibold tracking-wide transition-opacity hover:opacity-85"
+                        >
+                            Play Wordle
+                        </NuxtLink>
+                    </ClientOnly>
                 </div>
             </template>
         </div>

--- a/plugins/pwa.client.ts
+++ b/plugins/pwa.client.ts
@@ -225,23 +225,22 @@ export default defineNuxtPlugin(() => {
         } catch {}
     });
 
-    // --- Start idle detection once game page is active ---
+    // --- Start idle detection only on game pages (set by useGamePage) ---
 
     watch(
-        () => gameStore.gameConfig.mode,
-        (mode) => {
+        () => gameStore.gameActive,
+        (active) => {
             stopIdleDetection();
-            if (mode && mode !== 'speed') {
+            if (active && gameStore.gameConfig.mode !== 'speed') {
                 startIdleDetection();
             }
-        },
-        { immediate: true }
+        }
     );
 
     watch(
         () => gameStore.showStatsModal,
         (showing, wasShowing) => {
-            if (wasShowing && !showing && gameStore.gameOver) {
+            if (wasShowing && !showing && gameStore.gameOver && gameStore.gameActive) {
                 resetIdleTimer();
             }
         }

--- a/stores/game.ts
+++ b/stores/game.ts
@@ -117,6 +117,8 @@ export const useGameStore = defineStore('game', () => {
     const gameConfig = ref<GameConfig>(
         createGameConfig('classic', 'en', { wordLength: WORD_LENGTH })
     );
+    /** True when a game page is mounted (set by useGamePage). */
+    const gameActive = ref(false);
     const boards = ref<BoardState[]>([createBoardState(0, '', MAX_GUESSES, WORD_LENGTH)]);
     const activeBoardIndex = ref(0);
 
@@ -2255,6 +2257,7 @@ export const useGameStore = defineStore('game', () => {
     return {
         // Multi-board architecture
         gameConfig,
+        gameActive,
         boards,
         activeBoardIndex,
         isMultiBoard,


### PR DESCRIPTION
## Summary

- **Sidebar language picker**: opens `LanguagePickerModal` instead of broken `navigateTo('/#languages')` — consistent with game pages
- **GameModePicker**: added close button (removed `no-close-button`) so users can dismiss without picking a mode
- **PageShell**: closes sidebar before opening language modal to avoid z-index stacking on mobile

## Context

On homepage, clicking the language in sidebar did nothing (navigated to same page with `#languages` hash). Now opens the same modal used on game pages. Sidebar closes first so mobile doesn't have two overlays competing.

## Test plan

- [ ] Homepage: open sidebar → click language → sidebar closes, language picker modal opens
- [ ] Game page: open sidebar → click language → sidebar closes, language picker modal opens  
- [ ] Homepage: click a language card → game mode picker opens with X close button
- [ ] Game mode picker: click X or backdrop → modal closes without navigating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language selection now opens in a dedicated modal popup.

* **Bug Fixes**
  * Daily and unlimited game progress are now saved separately, preventing mode conflicts.
  * Start action is now guarded to prevent overlapping game starts.

* **UI/UX Improvements**
  * Sidebar auto-closes when opening the language picker.
  * Modal close button restored for game mode picker.
  * Mobile: improved scroll-lock during input and simplified map/leaderboard header behavior.
  * Retry preserves selected game mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->