### PR TITLE
fix: DB connection retry for OAuth login

### DIFF
--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -20,7 +20,10 @@ import type { GameResult } from '~/utils/types';
 
 // PWA install — show "Install App" CTA if not already installed
 const pwaInstall = import.meta.client
-    ? inject<{ install: () => void; status: () => { isStandalone: boolean } }>('pwaInstall', undefined)
+    ? inject<{ install: () => void; status: () => { isStandalone: boolean } }>(
+          'pwaInstall',
+          undefined
+      )
     : undefined;
 const showInstallCta = computed(() => {
     if (!import.meta.client) return false;

--- a/server/routes/auth/google.get.ts
+++ b/server/routes/auth/google.get.ts
@@ -1,37 +1,57 @@
 import { prisma } from '~/server/utils/prisma';
 import { usernameFromEmail } from '~/server/utils/name-generator';
 
+/** Retry a DB operation once on transient connection errors (ECONNREFUSED, etc.) */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+        return await fn();
+    } catch (err: any) {
+        const code = err?.cause?.code ?? err?.code;
+        if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'ETIMEDOUT') {
+            console.warn('[auth] DB connection failed, retrying once:', code);
+            return await fn();
+        }
+        throw err;
+    }
+}
+
 export default defineOAuthGoogleEventHandler({
     config: {
         scope: ['openid', 'email', 'profile'],
     },
     async onSuccess(event, { user: googleUser }) {
         // Check if user already exists (returning login)
-        let user = await prisma.user.findUnique({ where: { googleId: googleUser.sub } });
+        let user = await withRetry(() =>
+            prisma.user.findUnique({ where: { googleId: googleUser.sub } })
+        );
 
         if (!user) {
             // New user — generate unique username from email
             const username = await usernameFromEmail(googleUser.email);
-            user = await prisma.user.create({
-                data: {
-                    username,
-                    googleId: googleUser.sub,
-                    email: googleUser.email,
-                    emailVerified: true,
-                    displayName: googleUser.name,
-                    avatarUrl: googleUser.picture,
-                },
-            });
+            user = await withRetry(() =>
+                prisma.user.create({
+                    data: {
+                        username,
+                        googleId: googleUser.sub,
+                        email: googleUser.email,
+                        emailVerified: true,
+                        displayName: googleUser.name,
+                        avatarUrl: googleUser.picture,
+                    },
+                })
+            );
         } else {
             // Returning user — update avatar/name
-            user = await prisma.user.update({
-                where: { id: user.id },
-                data: {
-                    emailVerified: true,
-                    displayName: googleUser.name,
-                    avatarUrl: googleUser.picture,
-                },
-            });
+            user = await withRetry(() =>
+                prisma.user.update({
+                    where: { id: user!.id },
+                    data: {
+                        emailVerified: true,
+                        displayName: googleUser.name,
+                        avatarUrl: googleUser.picture,
+                    },
+                })
+            );
         }
 
         await setSessionForUser(event, user, 'google');

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -23,8 +23,9 @@ function createClient(): PrismaClient {
         connectionString,
         ssl: { rejectUnauthorized: false },
         max: 10,
-        idleTimeoutMillis: 30000,
-        connectionTimeoutMillis: 10000,
+        min: 2, // Keep warm connections to avoid cold-start on first request
+        idleTimeoutMillis: 60000, // 1 min — keep connections alive longer between requests
+        connectionTimeoutMillis: 15000, // 15s — generous for transient network hiccups
     });
 
     pool.on('error', (err) => {


### PR DESCRIPTION
## Problem
Google OAuth login fails with 500 when the DB connection is refused (transient issue during deploys). The OAuth code is consumed on the failed attempt, so retrying from the browser gets `invalid_grant` from Google.

## Fix
- **Retry logic**: `withRetry()` wrapper catches ECONNREFUSED/ECONNRESET/ETIMEDOUT and retries the DB call once. If the first connection fails, the retry typically succeeds as the pool establishes a new connection.
- **Pool tuning**: `min: 2` keeps warm connections so the first request post-deploy doesn't cold-start. `idleTimeoutMillis: 60000` keeps connections alive longer. `connectionTimeoutMillis: 15000` allows more time for transient hiccups.

## Context
DB upgraded to Basic-1gb (1GB RAM, 0.5 CPU). 103 max connections, ~8 active. The ECONNREFUSED was transient, not from exhaustion.

## Test
- Deploy → immediately try Google login → should succeed (retry catches the cold connection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Google authentication reliability with automatic retry logic to gracefully handle transient database connection failures and reduce login interruptions.
  * Optimized database connection pooling configuration with extended timeout thresholds and minimum connection reserves for improved application stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->