### PR TITLE
feat: native comments, bug reports, dictionary, type safety

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ RESEND_API_KEY=""
 # Base URL for links in emails (verification, password reset).
 NUXT_BASE_URL="http://localhost:3000"
 
+# ─── Reports ───
+# Email address for bug reports and feedback. Defaults to hugo@wordle.global.
+REPORT_EMAIL=""
+
 # ─── Dev tools ───
 # Set to "true" to enable /api/auth/dev-login (bypasses OAuth for testing).
 # NEVER enable in production.

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 docs/
 
 # Design exploration HTML mockups (local only)
+design/
 public/design-explorations/
+public/comments-exploration.html
 
 # Node.js / Frontend
 node_modules/
@@ -48,6 +50,9 @@ scripts/.freq_data
 
 # Curation review temp files
 scripts/.curation_review/
+
+# Processed kaikki dictionary data (190MB+, regenerate with import_dictionary.py)
+scripts/.kaikki_processed/
 .mcp.json
 
 # Archive (legacy assets, not tracked)

--- a/TODO.md
+++ b/TODO.md
@@ -1,531 +1,90 @@
-# Hebrew Bugs — Investigation & Fix Plan (2026-03-19)
+# Wordle Global — TODO
 
-Hebrew has 885 weekly sessions but only 7% completion rate (vs 37% baseline).
-Four bugs found during investigation. Bugs #1, #1b, and #2 are **systemic**.
+## Bugs
 
----
+- [x] **Hebrew blocklist too large** — 57K blocked→valid (fixed 2026-03-20)
+- [x] **Multi-board missing analytics** — added trackGameComplete to dordle/quordle handlers (fixed 2026-03-21)
+- [x] **Definitions missing for 57+ languages** — rewritten to DB-backed 2-tier system (LLM + kaikki)
+- [x] **Keyboard colors wrong for final-form letters** — Hebrew כ↔ך etc, Greek σ↔ς. normalizeMap now includes final_form_map
+- [x] **`/en/speed` 500 error** — useGameShare composable missing, fixed
+- [x] **Dordle/quordle pages duplicated** — consolidated into `pages/[lang]/[mode].vue`
+- [ ] **Hebrew checkWord() rejects final-form words** — `checkWord()` should normalize final forms before lookup. Low real-world impact (only ~68 obscure words affected)
+- [ ] **Hardcoded "6" in community percentile** — `utils/stats.ts`, `server/utils/word-stats.ts` reject attempts > 6. Non-classic modes can't record community stats. Fix: pass `maxGuesses` from GameConfig
+- [ ] **English-only strings in speed/multi-board UI** — StatsModal, SpeedResults, MultiBoardLayout, AppSidebar have hardcoded English. Route through `language_config.json`
 
-## Bug 1: Keyboard colors wrong key for final-form letters (SYSTEMIC)
+## Semantic Explorer
 
-**Impact**: Hebrew (5 letter pairs) + Greek (σ/ς). Misleading keyboard feedback.
-**Severity**: High — keyboard shows wrong letters as green/yellow, confusing players.
+- [ ] **#16 Viewport-locked layout** — semantic.vue uses scrollable layout while all other modes use viewport-locked PageShell. Causes double scrollbar, map overflow, input below fold. Proper fix: flex columns, no page-level scroll. Consolidates #21 and #24
+- [ ] **#21 Mobile layout reorder** — guesses list at top, compass below, map below that, input pinned to bottom. Prioritizes typing-relevant info over the visual map
+- [ ] **#24 Virtual keyboard covers input** — partially fixed with `preventScroll`. Proper fix: `visualViewport` API to offset input by keyboard height. Moot if #16 is done first
+- [ ] **#9 Mobile tabbed bottom panel** — Rank / Compass / List tabs instead of vertical stack. Eliminates scroll during gameplay
+- [ ] **#17 OG image** — design `public/images/og-semantic.png` (1200x630) with meaning map + editorial aesthetic
+- [ ] **#18 Best starting words** — add semantic-specific tips to `/en/best-starting-words`
 
-### Root cause
+## Word Pages & Dictionary
 
-When user types פ (regular pe) at the last position:
+- [ ] **Bulk kaikki import** — download kaikki.org JSONL dumps for all 79 languages, extract structured dictionary data (senses, etymology, IPA, forms, translations) into Postgres `definitions` table. Script: modify `scripts/deprecated/build_definitions.py`. Native editions for 13 langs (cs, de, el, es, fr, it, ko, nl, pl, pt, ru, tr, vi), English edition for the rest. ~1.2 GB for all 1.4M words.
+- [ ] **Native language definitions** — for the 13 languages with native kaikki editions, import native-language glosses instead of English. Show native as default, English as secondary.
+- [ ] **Definition fallback chain** — when LLM fails, fall back to kaikki data before writing negative cache. Never overwrite a kaikki definition with a negative entry.
+- [ ] **Multi-length word lists** — expand beyond 5-letter words for semantic explorer in all languages. Enables cross-language translation links for words of any length.
+- [ ] **Cross-language word links via translations** — kaikki `translations` field maps words between languages. Currently seeded for test words; bulk import will populate for all words. Translation links auto-expand as word lists grow.
 
-1. `addChar()` (game.ts:259) calls `toFinalForm('פ', true, config)` → stores **ף** in tile
-2. `updateColors()` (game.ts:320) reads `guessChar = 'ף'` from tile
-3. `pendingKeyUpdates` (game.ts:326) stores `{ char: 'ף' }`
-4. `updateKeyColor('ף', ...)` (game.ts:395) colors the **ף** key on keyboard
-5. The **פ** key (which user actually pressed) stays uncolored
+## SEO & Content
 
-`updateKeyColor` (game.ts:397-408) propagates colors via `normalizeMap`, but that's built
-from `diacritic_map` only (utils/diacritics.ts:30). It does NOT include `final_form_map`.
+- [ ] **Redesign share images** — `scripts/generate_share_images.py` still uses old dark theme. Update to editorial design system colors
+- [ ] **Submit new URLs to GSC** — 400+ game mode URLs in sitemap, not yet crawled. Submit sitemap + request indexing for top 50
+- [ ] **#19 useGameSeo refactor** — silent 60-char title truncation, hardcoded `| Wordle English` suffix. Add per-mode configurable suffix + length validation
 
-### Affected languages
+## Stats & Sync
 
-| Language | final_form_map | Letter pairs |
-|----------|---------------|--------------|
-| **Hebrew** | כ↔ך, מ↔ם, נ↔ן, פ↔ף, צ↔ץ | 5 pairs, all on keyboard |
-| **Greek** | σ↔ς | 1 pair (21% of daily words end with ς) |
+- [ ] **#12 Stats modal redesign** — show daily + unlimited stats per mode in separate sections. Data already split (`en_dordle` vs `en_dordle_daily`)
+- [ ] **#14 Sync endpoint: coerce att:0 on losses** — old localStorage stored `attempts: 0` for losses. Coerce to `maxGuesses`. Affects 48 legacy records
+- [ ] **#15 Reactive stats store** — make `stats` a `computed` derived from reactive `gameResults` + `currentStatsKey` instead of imperative `calculateStats()`. Eliminates stale-stats bugs
 
-### Fix
+## Infrastructure
 
-In `updateKeyColor()` (game.ts:371-409), after the diacritic propagation block,
-also propagate to final/regular form pairs:
-
-```typescript
-// Also update final form ↔ regular form pairs
-const config = lang.config ?? {};
-if (config.final_form_map) {
-    const finalForm = config.final_form_map[char];
-    if (finalForm) updateSingleKey(finalForm, newState);
-
-    const regularForm = lang.finalFormReverseMap.get(char);
-    if (regularForm) updateSingleKey(regularForm, newState);
-}
-```
-
----
-
-## Bug 1b: checkWord() rejects valid Hebrew words (CRITICAL — likely cause of 7%)
-
-**Impact**: Hebrew and Greek. Words typed with final forms may fail validation.
-**Severity**: CRITICAL — this likely causes most of the 7% completion rate.
-
-### Root cause
-
-When user types a word and presses Enter:
-
-1. `addChar()` at position 4 converts פ→ף via `toFinalForm`
-2. Tiles now contain e.g. `['פ','י','ל','ג','ף']` (note ף at end)
-3. `enterGuess()` (game.ts:463): `const typedWord = row.join('').toLowerCase()` → `"פילגף"`
-4. `checkWord("פילגף")` checks:
-   - `wordListSet.has("פילגף")` → **false** (word list has `"פילגש"`, not `"פילגף"`)
-   - `normalizeWord("פילגף", normalizeMap)` — normalizeMap is diacritics only, doesn't
-     convert final forms → still `"פילגף"`
-   - `getNormalizedWordMap().get("פילגף")` → **miss** (map was built with regular forms)
-   - Returns **null** → word rejected as invalid!
-
-Wait — the word פילגש ends with ש which has no final form. So this specific word wouldn't
-hit the bug. But ANY Hebrew word the user tries to guess where they type a final-form letter
-(כ→ך, מ→ם, נ→ן, פ→ף, צ→ץ) at the last position WILL fail validation if the word list
-stores the word with a regular form at that position (which shouldn't happen for properly
-formed Hebrew — final forms should be at the end).
-
-### When does it actually break?
-
-The bug triggers when:
-- User types a letter with a final form variant at position 4 (last)
-- `toFinalForm` converts it to the final form
-- The word in the word list ALSO has the final form at that position
-- → In this case it should MATCH (both have final form)
-
-But it breaks when:
-- User types e.g. "שלמ" (3 letters), backspaces, retypes — intermediate states may leave
-  final forms in non-final positions
-- Or: the word list has inconsistent final form usage
-
-### Verification needed
-
-```bash
-# Check: do ALL Hebrew words in word list use proper final forms at end?
-python3 -c "
-import json
-d = json.load(open('data/languages/he/words.json'))
-finals = {'ך':'כ', 'ם':'מ', 'ן':'נ', 'ף':'פ', 'ץ':'צ'}
-regulars = {v:k for k,v in finals.items()}
-for w in d['words'][:20]:
-    word = w['word']
-    # Check if last char SHOULD be final but isn't
-    if word[-1] in regulars:
-        print(f'  {word} — ends with {word[-1]} (should be {regulars[word[-1]]}?)')
-"
-```
-
-### Fix
-
-In `checkWord()` (game.ts:276-291), normalize final forms to regular forms before lookup:
-
-```typescript
-function checkWord(word: string): string | null {
-    // Normalize positional final forms → regular forms before lookup
-    const lang = useLanguageStore();
-    let normalized = word;
-    if (lang.finalFormReverseMap.size > 0) {
-        normalized = [...word].map(c => lang.finalFormReverseMap.get(c) || c).join('');
-    }
-
-    if (lang.wordListSet.has(normalized)) return normalized;
-    // ... rest of existing logic
-}
-```
-
-### Backspace edge case
-
-`deleteChar()` (game.ts:581-590) doesn't re-evaluate final forms when removing the last char.
-If user types "שלמ" where מ is at pos 2 (not final, stays מ), then types at pos 3 where the
-new char becomes final, then backspaces — the char at pos 2 doesn't get re-evaluated.
-This can leave regular forms where final forms are expected and vice versa.
-
----
-
-## Bug 2: No definition or word image shown after game over (SYSTEMIC)
-
-**Impact**: Hebrew + likely 70+ other languages without pre-cached definitions.
-**Severity**: Medium — missing content, doesn't block gameplay.
-
-### Root cause
-
-Definition system is 3-tier: disk cache → LLM (GPT-5.2) → kaikki (offline Wiktionary).
-
-For Hebrew (פילגש):
-- **Disk cache**: `word-defs/he/` doesn't exist (only de, en, es cached)
-- **LLM**: Needs `OPENAI_API_KEY`. If set and returns confidence < 0.3, writes negative cache
-- **Kaikki**: `he.json` (native) missing. `he_en.json` exists and HAS the word
-
-The kaikki English fallback SHOULD return `{ definition: "mistress, concubine..." }`.
-
-Most likely failure: LLM is called (key is set on production), returns null or low confidence,
-**negative cache is written** (definitions.ts:318: `{ not_found: true, ts: ... }`).
-Subsequent requests within 24h hit the negative cache and return null. Kaikki is never reached.
-
-### Verified on production
-
-```
-Hebrew:   GET /api/he/definition/פילגש  → 404
-Arabic:   GET /api/ar/definition/كتاب   → 404
-Croatian: GET /api/hr/definition/kuća   → 404
-English:  GET /api/en/definition/hello  → 200 (LLM cached)
-Finnish:  GET /api/fi/definition/koira  → 200 (native kaikki)
-German:   GET /api/de/definition/hallo  → 200 (native kaikki)
-```
-
-**Pattern**: Languages with native kaikki files work. Languages with ONLY `_en.json` fail.
-
-### Kaikki file coverage
-
-- **13 languages** have native `{lang}.json`: cs, de, el, en, es, fr, it, nl, pl, pt, ru, tr, vi
-- **57 languages** have only `{lang}_en.json` (English definitions) — ALL returning 404
-- **25 languages** have no kaikki files at all
-
-### Root cause (confirmed)
-
-The LLM (GPT-5.2) is called first on production (OPENAI_API_KEY is set). For non-Western
-words it either returns low confidence or fails. Then a **negative cache** is written
-(`{ not_found: true, ts: ... }`). The kaikki fallback IS tried in the same request, but
-if it ALSO returns null (e.g., lookup fails), the negative cache persists for 24h.
-
-The English kaikki lookup (`lookupKaikki(word, lang, 'en')`) should work for Hebrew since
-`he_en.json` has the word. But on production the file may not be found (path resolution
-issue) or the lookup is failing for another reason.
-
-### Fix
-
-The definitions code has **zero logging** outside the LLM path. Kaikki lookups, negative
-cache hits, file existence checks, and final results are all silent. We can't diagnose
-further from Render logs — need to add logging and redeploy.
-
-Add to `server/utils/definitions.ts`:
-
-```typescript
-// In resolveDefinitionsDir() — log once at startup:
-console.log(`[DEFS] Definitions dir: ${result}`);
-
-// In loadKaikkiFile() — log file existence:
-console.log(`[KAIKKI] Loading ${filePath}: exists=${existsSync(filePath)}, keys=${Object.keys(result).length}`);
-
-// In fetchDefinition() — log the decision at each tier:
-console.log(`[DEFS] ${langCode}/${word}: cache=${existsSync(cachePath) ? 'hit' : 'miss'}`);
-// After LLM:
-console.log(`[DEFS] ${langCode}/${word}: llm=${result ? 'ok' : 'null'}`);
-// After kaikki:
-console.log(`[DEFS] ${langCode}/${word}: kaikki=${result ? result.source : 'null'}`);
-// Final:
-console.log(`[DEFS] ${langCode}/${word}: final=${result ? result.source : 'not_found'}`);
-```
-
-This will reveal whether: (a) kaikki file isn't found on Render, (b) negative cache is
-blocking, or (c) the lookup key doesn't match. One deploy and we'll know.
-
-### Systemic scope — LARGE
-
-57 languages with English-only kaikki are all affected. This includes Arabic (2.1K sessions/wk),
-Croatian (1.3K), Bulgarian (963), Hebrew (885), Swedish (1K), and many more.
-Only 13 Western European languages have working definitions.
-
----
-
-## Bug 3: Day index (NOT a production bug)
-
-Local debugging used wrong epoch. Production formula is:
-`dayIdx = nDaysSinceUnixEpoch - 18992 + 195` → day 1734 for 2026-03-19.
-Correctly uses consistent hash (1734 > MIGRATION_DAY_IDX 1681).
-
----
-
-## Systemic Assessment
-
-### Which languages are affected by which bugs?
-
-| Bug | Languages | Sessions/week | Severity |
-|-----|-----------|--------------|----------|
-| #1 keyboard colors | Hebrew, Greek | 885 + 54 | High |
-| #1b checkWord rejection | Hebrew, Greek | 885 + 54 | **CRITICAL** |
-| #2 missing definitions | ~76 languages | most traffic | Medium |
-
-### Greek impact
-
-Greek has 29% completion (PostHog 12h: 7 starts, 2 completes). With only σ↔ς as the
-final form pair, 21% of daily words end with ς. Both bugs #1 and #1b apply.
-Greek's low completion may be partly caused by these bugs.
-
-### Other languages unaffected by final form bugs
-
-All other languages (including Arabic, Persian, Korean) don't have `final_form_map` in their
-config. Their issues are separate (RTL input, composition scripts, etc.).
-
----
-
-## Bug 4: Hebrew blocklist massively too large (ROOT CAUSE of 8.5% completion)
-
-**Impact**: Hebrew — 885 sessions/week, 8.5% completion.
-**Severity**: CRITICAL — this is the primary cause of Hebrew's broken completion rate.
-
-### Root cause
-
-Hebrew had **57,483 blocked words (57% of total)** — vs 0-4% for every other language.
-Common everyday words like ישראל (Israel), אנחנו (we), ילדים (children), מחלקה (department),
-מכבסה (laundromat), שמיעה (hearing) were all blocked. Users type normal Hebrew words and
-get "word not valid" → give up.
-
-The blocklist was imported during the word pipeline migration and never reviewed. An update
-on Mar 15 intended to remove prefixed forms from DAILY tier but moved them to valid, not
-blocked. The 57K blocked words predate that commit.
-
-### Fix (DONE 2026-03-20)
-
-Moved all 57,483 Hebrew `blocked` → `valid`. Now: daily=1,018, valid=99,664, blocked=0.
-Words are guessable but won't be selected as the daily word.
-
-### Follow-up needed
-
-- **LLM curate the 57K promoted words**: Some may be genuine gibberish, conjugated
-  fragments, or transliterations that shouldn't be guessable. Run LLM curation to review
-  and re-block true garbage while keeping real Hebrew words as valid.
-- **Check Irish (ga)**: 12% blocked (602 words) — given Irish already has 80% invalid
-  word rate, this may be making it worse. Review and promote if appropriate.
-- **Audit all languages**: Verify no other language has an accidentally aggressive blocklist.
-
----
-
-## Priority
-
-1. **P0 — DONE: Fix Bug 4** (Hebrew blocklist) — 57K blocked→valid. Deploy needed.
-2. **P1 — Fix Bug 1** (keyboard sofit color propagation) — cosmetic but confusing for Hebrew/Greek.
-3. **P1 — Fix Bug 2** (definitions) — add diagnostic logging, deploy, check Render logs.
-4. **P2 — Bug 1b** (checkWord sofit) — only affects 68 obscure words, not a real issue.
-5. **P2 — LLM curate Hebrew's 57K promoted words** — clean up true garbage.
-6. **P2 — Generate native definition files** for high-traffic languages beyond en/de/es.
-7. **P3 — Push notifications** — "Your daily Wordle is ready!" via Notification API. Works on
-   desktop Chrome/Edge/Firefox without PWA install. Highest-ROI retention feature for desktop.
-   One-time permission prompt, daily trigger to bring users back.
-8. **P3 — Email digest** — "Your streak is at 47 days!" daily/weekly reminder. Heavier to build
-   (needs email service + subscription flow) but powerful for retention.
-9. **P4 — Homepage/new tab extension** — Chrome extension that shows Wordle on new tab. Niche
-   but high engagement for power users.
-
----
-
-# Phase 1 Audit — Remaining Items (2026-03-20)
-
-## Medium Priority (should fix before production)
-
-### ~~Multi-board missing analytics~~ ✅ FIXED (2026-03-21 hotfix)
-Added `analytics.trackGameComplete()` with `game_mode`, frustration state, and timing to both `handleMultiBoardWon()` and `handleMultiBoardLost()`. Dordle/tridle/quordle completions now tracked.
-Speed streak already tracked via `speed_session_complete` event (added by design agent).
-
-### Hardcoded "6" in community percentile + word stats
-**Files:** `utils/stats.ts:27,31`, `server/utils/word-stats.ts:98`
-**Issue:** `calculateCommunityPercentile` rejects attempts > 6. Server-side word stats recording ignores attempts > 6.
-**Impact:** Non-classic modes (dordle=7, tridle=8, quordle=9, semantic=10) can't submit/display community stats.
-**Fix:** Pass `maxGuesses` from `GameConfig` to both functions.
-
-### Dordle/tridle/quordle pages are 95% identical
-**Files:** `pages/[lang]/dordle.vue`, `pages/[lang]/tridle.vue`, `pages/[lang]/quordle.vue`
-**Issue:** ~90 lines each, differing only in mode string and SEO text.
-**Fix:** Consolidate into `pages/[lang]/[mode].vue` dynamic route, or extract shared template into a thin wrapper.
-
-## SEO Follow-ups (2026-03-21)
-
-### Redesign classic share images to match editorial design system
-**Files:** `scripts/generate_share_images.py`, `public/images/share/` (553 files)
-**Issue:** Share result images (e.g., en_3.png) still use old dark theme (#171717 background, Tailwind green #22c55e). Don't match the new editorial design system.
-**Fix:** Update `generate_share_images.py` to use design system colors (paper background, correct green #2d8544, Wordle.Global masthead). Regenerate all 553 images.
-
-### Submit new URLs to Google Search Console
-**Issue:** 400+ new game mode URLs are in the sitemap but Google hasn't crawled them yet.
-**Fix:** Go to Google Search Console → Sitemaps → submit `https://wordle.global/sitemap.xml`. Then request indexing for top 50 URLs (top 10 languages × 5 modes).
-
-### `/en/speed` 500 error — `useGameShare is not defined`
-**Files:** `pages/[lang]/speed.vue`
-**Issue:** Speed mode page crashes on SSR. `useGameShare` composable is referenced but not defined — likely from the BoardState refactor agent's changes.
-**Fix:** The other agent needs to create/export the `useGameShare` composable or fix the import.
-
-## Low Priority (cleanup)
-
-### English-only strings in speed/multi-board UI
-**Files:** StatsModal, SpeedResults, SpeedStatsStrip, MultiBoardLayout, AppSidebar
-**Issue:** Strings like "Solved in N guesses", "Board 1", "Tap to expand", "Speed Streak", sidebar labels are hardcoded English.
-**Fix:** Route through `language_config.json` UI translations (i18n). Phase 2 work.
-
-### Unused exports in game-modes.ts
-**Exports:** `SocialMode`, `PlayType`, `GameModeDefinition`
-**Issue:** Defined for future use (party mode, etc.) but not currently imported.
-**Fix:** Keep — they're part of the planned architecture.
-
-### Unused helpers in storage.ts
-**Exports:** `removeLocal`, `readBool`, `writeBool`, `readJson`, `writeJson`, `dismissWithCooldown`, `isDismissedWithCooldown`
-**Issue:** Pre-existing dead code, not from our refactor.
-**Fix:** Low priority cleanup.
-
----
-
-# Daily/Unlimited System — Open Decisions (2026-04-10)
-
-These items need owner input before or during implementation. None block Phases 1-3.
-
-### 1. `/en/unlimited` page long-term
-Add `<link rel="canonical" href="/en?play=unlimited">` now, or keep both pages independent?
-- **Recommendation**: Add canonical now. Keep the page working. Soft-deprecate later.
-
-### 2. Daily Speed word pool size
-How many deterministic words in the daily speed pool? Most players solve 10-20 in 5 min.
-- **Recommendation**: 50, hardcoded.
-
-### 3. First-visit UX for daily multi-board
-Player first visits `/en/dordle?play=daily` — empty game, no saved state. Show banner?
-- **Recommendation**: No banner. Same as classic daily first visit.
-
-### 4. Language picker component reuse
-Extract homepage language grid into shared component for modal reuse, or build independently?
-- **Recommendation**: Build independently, refactor later.
-
-### 5. Archive mode tabs — data timeline
-Mode filter tabs on archive page: when to implement per-mode daily word history?
-- **Recommendation**: Ship tabs with Classic only. Per-mode archive data is separate project.
-
-### 6. Multi-board archive card design
-For 8+ boards, cards become summaries. Implement card variants now or stub?
-- **Recommendation**: Stub with "Coming soon". Full variants are separate design task.
-
-### 7. Word page "Appeared in" section
-Cross-mode daily history on word detail pages. Needs server-side cross-mode word index.
-- **Recommendation**: Defer. Index doesn't exist yet.
-
-### 8. Homepage mode cards redesign
-Homepage still shows old flat mode list with hardcoded `HOMEPAGE_MODE_IDS`. Needs:
-- Remove standalone "unlimited" card (it's Classic's unlimited variant)
-- Add daily/unlimited labels per mode card
-- For returning users: adapt cards to game state (in-progress, solved, "Play Unlimited →")
-- Feature Semantic Explorer prominently
-- Design explorations exist in editorial page (Screen 01, F1 Hub) and system design doc (section 7) but no final design decided
-
-### 9. Semantic mobile tabbed bottom panel
-Current mobile semantic layout stacks map + leaderboard + compass vertically — player must scroll between them. A tabbed bottom panel (Rank / Compass / List tabs) would show one section at a time above the fixed input, eliminating scroll during gameplay. Described in session but not implemented.
-
-### 10. Verify `useFetch` key with playType
-`pages/[lang]/[mode].vue` uses `key: 'lang-data-${lang}-${mode}-${playType.value}'`. If `playType` changes after initial SSR (e.g., localStorage preference read), the cached response may be stale. Likely a non-issue because page remounts on route change, but needs explicit verification.
-
-### 11. Sidebar visual polish
-- Sub-panel dismiss behavior when clicking different modes (implemented but not verified)
-- Active border-left vs sub-panel warm-bg highlight conflict (CSS added but not verified)
-- Daily multi-board persistence end-to-end test (save/restore on reload)
-
-### 12. Stats modal/page redesign — combined daily + unlimited view
-Stats should show both play types per mode: daily stats (with streak) and unlimited stats (play count, win rate, no streak) in separate sections. Current stats modal only shows one set of stats per mode. Needs:
-- Stats modal: two-section layout (Daily / Unlimited) for modes that support both
-- Stats page (`/stats`): same combined view with mode tabs
-- Existing stats data is preserved — `"en_dordle"` (unlimited) and `"en_dordle_daily"` (daily) are already separate keys
-- No data migration needed, just a UI redesign to surface both
-
----
-
-## CI / Infrastructure
-
-### 13. Ephemeral Postgres for CI tests
-E2E and integration tests currently hit the production database, creating junk accounts (86 cleaned up on 2026-04-11). Tests should use an ephemeral Postgres instance instead.
-
-**Approach:** GitHub Actions service container:
-```yaml
-services:
-  postgres:
-    image: postgres:16
-    env:
-      POSTGRES_DB: wordle_test
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: test
-    ports:
-      - 5432:5432
-```
-Then set `DATABASE_URL=postgresql://test:test@localhost:5432/wordle_test` in CI env, run `prisma db push` before tests. Zero test data in prod.
-
-### 14. Sync endpoint: coerce att:0 on losses
-Old localStorage results stored losses as `{ won: false, attempts: 0 }` because attempt count wasn't tracked on losses. The `/api/user/sync` POST endpoint should coerce `attempts: 0` on `won: false` results to `attempts: maxGuesses` (6 for classic). Affects 48 legacy records from 6 users (confirmed 2026-04-11).
-
-### 15. Make stats store reactive instead of imperative
-Currently `stats` is a manually-triggered snapshot: `calculateStats(key)` reads `gameResults` and writes to `stats` ref. Any code that reloads `gameResults` without calling `calculateStats` produces stale/empty stats (bug hit on 2026-04-11 with scoped storage — fixed with a band-aid in `loadGameResults`).
-
-**Correct architecture:** make `stats` a `computed` that derives from reactive `gameResults` + a reactive `currentStatsKey`:
-```ts
-const currentStatsKey = ref<string>();
-const currentMaxGuesses = ref(6);
-const stats = computed(() => {
-    if (!currentStatsKey.value) return emptyStats(currentMaxGuesses.value);
-    const results = gameResults.value[currentStatsKey.value];
-    return results?.length ? computeStats(results, currentMaxGuesses.value) : emptyStats(currentMaxGuesses.value);
-});
-```
-Then `calculateStats(key, max)` becomes `setStatsKey(key, max)` — just sets the refs, Vue handles the rest. Eliminates the entire class of "forgot to recalculate" bugs. Touches: `stores/stats.ts`, `composables/useGamePage.ts`, `pages/profile.vue`.
-
-### 16. Semantic Explorer: viewport-locked layout (like other game modes)
-The semantic page uses a scrollable layout (`overflow-y: auto` on `.semantic-body`) while every other game mode uses `h-[100dvh]` viewport-locked layout via `PageShell`. This causes:
-- Double scrollbar on short desktops (page scroll + browser scroll)
-- Map SVG overflows its `max-height` container because it renders at intrinsic 520px
-- `min-height: 280px` fights `max-height: calc(100dvh - 310px)` on short viewports
-- Input gets pushed below the fold
-
-**Proper fix:** Refactor `semantic.vue` to use viewport-locked layout like `PageShell`:
-- Left column (map + input): flex column, map grows to fill, input pinned to bottom
-- Right column (compass + hint + leaderboard): flex column with overflow scroll
-- No page-level scroll — everything fits in viewport
-- Expand button goes truly fullscreen (overlay), not just "fill the column"
-
-Current band-aid: `min-height: min(200px, calc(100dvh - 310px))` prevents `min-height` from exceeding viewport, but the SVG still overflows on short desktops. `:deep()` CSS hacks were tried and reverted because they broke the expanded map aspect ratio.
-
----
+- [ ] **#13 Ephemeral Postgres for CI** — E2E tests hit production DB, creating junk accounts. Use GitHub Actions Postgres service container
+- [ ] **#22 Image thumbnail optimization** — generate 300px thumbnails alongside 1024px originals. Archive pages load 960KB of images displayed at 200px; thumbnails would be 60KB total
 
 ## DB Migration — Remove Disk Fallback Paths
 
-**Added**: 2026-04-12
-**Status**: Monitoring — disk fallback paths emit console.warn when hit
+**Status**: Monitoring — disk fallback paths emit console.warn when hit. Target: ~2026-04-26.
 
-Data has been migrated from Render's persistent disk to Postgres:
-- 253K definitions (77K kaikki native + 98K kaikki-en + 77K LLM, source/model provenance tracked)
-- 2.8K word stats
-- 50K embeddings with UMAP/PCA2D coordinates, 70 axes, 4.4M neighbor ranks
-- `model` column added to definitions table (gpt-5.2, wiktionary-kaikki-2024, legacy-unknown)
-
-### Phase 1: Remove disk fallback code (after 2 weeks stable, ~2026-04-26)
-
-- [ ] `server/utils/definitions.ts` — remove Tier 1 disk read, disk write, kaikki in-memory cache (`_kaikkiCache`, `loadKaikkiFile`, `lookupKaikki`, `resolveDefinitionsDir`, `DEFINITIONS_DIR`). Kaikki data is now in the `definitions` table with source='kaikki'/'kaikki-en'.
-- [ ] `server/utils/word-stats.ts` — remove disk read/write fallback + `proper-lockfile` dependency
-- [ ] `server/utils/wiktionary.ts` — remove `readCache`/`writeCache` disk functions
-- [ ] `server/api/[lang]/semantic/hint.post.ts` — remove disk read/write for hints
-- [ ] `server/utils/data-loader.ts` — remove `WORD_DEFS_DIR`, `WORD_STATS_DIR` exports
+### Phase 1: Remove disk fallback code
+- [x] `definitions.ts` — disk fallback removed (DB-only)
+- [x] `word-stats.ts` — disk fallback removed (DB-only via db-cache.ts)
+- [x] `wiktionary.ts` — disk fallback removed (DB-only via db-cache.ts)
+- [x] `hint.post.ts` — no disk I/O (LLM with DB session cache)
+- [x] `semantic.ts` legacy in-memory loader — endpoints migrated to `_semantic-db.ts`
+- [ ] `data-loader.ts` — still exports `WORD_DEFS_DIR`, `WORD_STATS_DIR`
 - [ ] Remove `proper-lockfile` from package.json
-- [ ] Remove fs imports (`existsSync`, `readFileSync`, `writeFileSync`, `mkdirSync`) from all above files
 
 ### Phase 2: Migrate remaining disk-dependent features
+- [ ] **Word history** → DB table `(lang, day_idx, word)`. Eliminates 546MB of `.txt` files
+- [ ] **Word images** → keep on Render disk ($0.40/mo) or move to Cloudflare R2
 
-- [ ] **Word history** → new DB table `(lang, day_idx, word)`. ~136K rows (80 langs × 1700 days). Eliminates 546MB of `.txt` files on Render disk and disk reads in `word-selection.ts`. Algorithm is deterministic but cache is a safety net against word list changes.
-- [ ] **Word images** → decide: keep on Render persistent disk ($0.40/month for 1.5GB), or move to Cloudflare R2 (free egress, ~$0.003/month for 204MB). Only feature still requiring the persistent disk. No urgency — current setup works.
-- [ ] **`semantic.ts` legacy in-memory loader** — `start.post.ts` and `word/[slug].get.ts` still import `loadSemanticData` which loads the 98MB embedding matrix. Migrate these two endpoints to use `_semantic-db.ts` (DB-backed), then delete `loadSemanticData`/`loadSemanticDataSafe`/`loadEmbeddings` and the entire in-memory path.
-
-### Phase 3: Remove committed heavy files from git
-
+### Phase 3: Remove heavy files from git
 - [ ] `data/semantic/embeddings.f32` + `embeddings.meta.json` (~99MB) — in pgvector
-- [ ] `data/semantic/embeddings.json` (~230MB if present) — in pgvector
 - [ ] `data/semantic/axes.json` — in `semantic_axes` table
 - [ ] `data/semantic/umap.json`, `pca2d.json` — in `word_embeddings` columns
-- [ ] `data/semantic/targets.json`, `vocabulary.json` — queryable from `word_embeddings`
-- [ ] Keep `data/semantic/valid_words.json` (loaded into memory for spellcheck, no DB table)
-- [ ] Keep `data/definitions/` as archive (kaikki data now in DB, but files are small and useful for re-seeding)
+- [ ] `data/semantic/targets.json`, `vocabulary.json` — queryable from DB
+- Keep: `valid_words.json` (runtime spellcheck), `data/definitions/` (archive for re-seeding)
 
-### 17. Semantic Explorer OG image
-Design and add `public/images/og-semantic.png` (1200x630) showing the meaning map with dots, compass needle, and the editorial aesthetic. Currently falls back to generic `og-image.png`.
+## Accounts & Passkeys
 
-### 18. Semantic best starting words
-Add semantic-specific content to the `/en/best-starting-words` page — tips for first guesses in semantic mode (broad category words, high-information starters). Could be a separate section or tab.
+- [ ] **Passkey signup flow broken on Apple** — `authenticate()` called first with no credentials triggers confusing "external passkey" OS dialog. After dismissal, error may not match cancel check → falls through to register. No success state after account creation (modal just closes). `authenticate.post.ts` looks up by `email` but passkey users have `null` email, so re-auth never works → loop creates duplicate accounts. Fixes: (1) don't authenticate-first for new users, (2) fix credential lookup, (3) set `authenticatorAttachment: 'platform'`, (4) add welcome/success state, (5) guard against double-registration
+- [ ] **Safari→PWA localStorage loss** — iOS gives PWAs a separate localStorage partition. Anonymous users lose all game history when installing. No cookie-based transfer exists. Fix: rework PWA install CTA to prompt sign-in first (so data syncs to server), only show install CTA after account exists. Fallback: cookie hack to serialize localStorage before install
 
-### 19. useGameSeo refactor
-- Silent 60-char truncation: configured titles are dropped without warning when too long. Should either warn at build time or use the configured title regardless.
-- Hardcoded `| Wordle English` suffix: not all modes benefit from Wordle brand. Add configurable suffix per mode.
-- No length validation at config time — easy to write titles/descriptions that get silently truncated.
+## Community & Comments
 
-### 21. Semantic mobile layout experiment
-On mobile, reorder the semantic layout:
-1. **Guesses list** at the very top (always visible above keyboard)
-2. **Compass hints** below guesses
-3. **Map** below compass (less important on mobile — player rarely needs it mid-guess)
-4. **Oracle hint** below map
-5. **Input** pinned to bottom (already done)
+- [ ] **Leaderboard discussion** — Add `WordComments` component to `/leaderboard` page with `targetType='leaderboard'` and `targetKey='{lang}-{mode}-{dayIdx}'`. Same component, different target. Consider spoiler gating: only show comments to users who've already played that day.
+- [ ] **Leaderboard daily bragging** — Surface comment count / teaser in the post-game panel: "3 players are talking about today's word" linking to leaderboard discussion.
+- [ ] **Comment admin tooling** — Simple admin page or Prisma Studio workflow to review reports (type='report'/'feedback') and moderate comments (toggle `hidden` flag). No UI yet.
+- [ ] **Resend email setup** — Configure `RESEND_API_KEY` in production `.env` to enable email notifications for bug reports, password reset, and email verification flows.
 
-This prioritizes the information the player actually needs while typing (rank feedback, compass direction) over the visual map. The map is still accessible by scrolling but doesn't dominate the viewport.
+## Open Design Decisions
 
-### 22. Image thumbnail optimization
-Generate a 300px thumbnail alongside the 1024px original when DALL-E images are created (one extra `sharp` call). Serve thumbnails on archive pages instead of full 1024x1024. Archive currently loads 12 × ~80KB = 960KB of images that display at ~200px. Thumbnails would be ~5KB each = 60KB total. Change is in `server/api/[lang]/word-image/[word].get.ts` — add a `?size=thumb` param.
-
-### 23. Language switcher preserves current page
-When switching language via the sidebar language picker, navigate to the same page type in the new language. For example, `/en/archive` → `/de/archive`, `/en/dordle` → `/de/dordle`. Currently always navigates to `/{lang}` (classic daily). The `LanguagePickerModal` has a `currentModeSuffix` prop that partially handles this but doesn't cover non-game pages like archive, best-starting-words, or word pages.
+- [ ] `/en/unlimited` canonical — add `<link rel="canonical" href="/en?play=unlimited">`?
+- [ ] Homepage mode cards redesign — remove standalone "unlimited" card, add daily/unlimited labels, feature Semantic prominently
+- [x] Language switcher preserves page — LanguagePickerModal now keeps path suffix when switching
+- [ ] Sidebar visual polish — sub-panel dismiss behavior, active border highlight (implemented, unverified)

--- a/app.vue
+++ b/app.vue
@@ -3,6 +3,7 @@ import { usePageDirection } from '~/composables/usePageDirection';
 
 const { direction } = usePageDirection();
 const { showLoginModal, closeLoginModal } = useLoginModal();
+const { showReportModal, closeReportModal } = useReportModal();
 
 /** Direction-aware page transition. No 'out-in' — it causes blank screens
  *  because Nuxt's Suspense blocks the enter while out-in already removed
@@ -29,4 +30,5 @@ useHead({
     </NuxtLayout>
     <AccountBadgeEarned />
     <AccountLoginModal :visible="showLoginModal" @close="closeLoginModal" />
+    <ReportModal :visible="showReportModal" @close="closeReportModal" />
 </template>

--- a/components/account/LoginModal.vue
+++ b/components/account/LoginModal.vue
@@ -4,7 +4,9 @@
             <!-- ── Step 1: Main login options ── -->
             <div v-if="step === 'main'" key="main" class="flex flex-col gap-4">
                 <h3 class="heading-section text-xl text-ink">Sign In</h3>
-                <p class="text-sm text-muted -mt-2">Sync your stats across devices and earn badges.</p>
+                <p class="text-sm text-muted -mt-2">
+                    Sync your stats across devices and earn badges.
+                </p>
 
                 <!-- Auth buttons — ordered by platform: passkey first on iOS, Google first elsewhere -->
                 <template v-for="method in authOrder" :key="method">
@@ -108,7 +110,11 @@
                 </div>
                 <h3 class="heading-section text-xl text-ink">{{ successMessage }}</h3>
                 <p class="text-sm text-muted">
-                    {{ isNewAccount ? 'Your passkey has been created.' : 'Signed in with your passkey.' }}
+                    {{
+                        isNewAccount
+                            ? 'Your passkey has been created.'
+                            : 'Signed in with your passkey.'
+                    }}
                 </p>
             </div>
         </Transition>
@@ -141,7 +147,7 @@ const { authenticate, register, isPlatformAvailable } = useWebAuthn({
 // everyone else gets Google first (path of least resistance on Android/desktop)
 const isIOS = ref(false);
 const authOrder = computed<Array<'google' | 'passkey'>>(() =>
-    isIOS.value ? ['passkey', 'google'] : ['google', 'passkey'],
+    isIOS.value ? ['passkey', 'google'] : ['google', 'passkey']
 );
 
 if (import.meta.client) {
@@ -163,7 +169,7 @@ watch(
             error.value = '';
             passkeyLoading.value = false;
         }
-    },
+    }
 );
 
 function goToPasskeyChoice() {

--- a/components/account/LoginModal.vue
+++ b/components/account/LoginModal.vue
@@ -1,124 +1,306 @@
 <template>
-    <BaseModal :visible="visible" size="sm" @close="$emit('close')">
-        <div class="flex flex-col gap-4">
-            <h3 class="heading-section text-xl text-ink">Sign In</h3>
-            <p class="text-sm text-muted -mt-2">Sync your stats across devices and earn badges.</p>
+    <BaseModal :visible="visible" size="sm" @close="handleClose">
+        <Transition :name="transitionName" mode="out-in">
+            <!-- ── Step 1: Main login options ── -->
+            <div v-if="step === 'main'" key="main" class="flex flex-col gap-4">
+                <h3 class="heading-section text-xl text-ink">Sign In</h3>
+                <p class="text-sm text-muted -mt-2">Sync your stats across devices and earn badges.</p>
 
-            <!-- Google OAuth -->
-            <button
-                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
-                @click="loginWithGoogle()"
-            >
-                <svg class="w-4 h-4" viewBox="0 0 24 24">
-                    <path
-                        fill="#4285F4"
-                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    />
-                    <path
-                        fill="#34A853"
-                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    />
-                    <path
-                        fill="#FBBC05"
-                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    />
-                    <path
-                        fill="#EA4335"
-                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    />
-                </svg>
-                Continue with Google
-            </button>
+                <!-- Auth buttons — ordered by platform: passkey first on iOS, Google first elsewhere -->
+                <template v-for="method in authOrder" :key="method">
+                    <button
+                        v-if="method === 'google'"
+                        class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
+                        @click="loginWithGoogle()"
+                    >
+                        <svg class="w-4 h-4" viewBox="0 0 24 24">
+                            <path
+                                fill="#4285F4"
+                                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                            />
+                            <path
+                                fill="#34A853"
+                                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                            />
+                            <path
+                                fill="#FBBC05"
+                                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                            />
+                            <path
+                                fill="#EA4335"
+                                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                            />
+                        </svg>
+                        Continue with Google
+                    </button>
 
-            <!-- Passkey — single button, handles both sign-in and registration -->
-            <button
-                v-if="passkeySupported"
-                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
-                :disabled="passkeyLoading"
-                @click="handlePasskey()"
-            >
-                <Fingerprint :size="16" />
-                {{ passkeyLoading ? 'Waiting...' : 'Continue with Passkey' }}
-            </button>
+                    <button
+                        v-else-if="method === 'passkey' && passkeySupported"
+                        class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
+                        @click="goToPasskeyChoice()"
+                    >
+                        <Fingerprint :size="16" />
+                        Continue with Passkey
+                    </button>
+                </template>
 
-            <div v-if="error" class="text-xs text-accent text-center">{{ error }}</div>
+                <div v-if="error" class="text-xs text-accent text-center">{{ error }}</div>
 
-            <!-- Email (coming soon) -->
-            <button
-                disabled
-                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm text-muted cursor-not-allowed opacity-50"
-            >
-                <Mail :size="16" />
-                Sign in with Email
-                <span class="mono-label ml-1">soon</span>
-            </button>
-        </div>
+                <!-- Email (coming soon) -->
+                <button
+                    disabled
+                    class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm text-muted cursor-not-allowed opacity-50"
+                >
+                    <Mail :size="16" />
+                    Sign in with Email
+                    <span class="mono-label ml-1">soon</span>
+                </button>
+            </div>
+
+            <!-- ── Step 2: Passkey — new or returning? ── -->
+            <div v-else-if="step === 'passkey'" key="passkey" class="flex flex-col gap-4">
+                <div>
+                    <button
+                        class="flex items-center gap-1.5 text-muted hover:text-ink transition-colors -ml-0.5 mb-3"
+                        @click="goBack()"
+                    >
+                        <ArrowLeft :size="15" :stroke-width="1.5" />
+                        <span class="text-xs">Back</span>
+                    </button>
+
+                    <div class="text-center">
+                        <span class="eyebrow">Passkey</span>
+                        <h3 class="heading-section text-xl text-ink mt-1.5">First time here?</h3>
+                    </div>
+                </div>
+
+                <!-- New user — create account -->
+                <button
+                    class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
+                    :disabled="passkeyLoading"
+                    @click="handleRegister()"
+                >
+                    <UserPlus :size="16" :stroke-width="1.5" />
+                    Create account
+                </button>
+
+                <!-- Returning user — sign in -->
+                <button
+                    class="w-full flex items-center justify-center gap-2 px-4 py-2.5 border border-rule rounded-md text-sm font-semibold text-ink hover:bg-paper-warm transition-colors"
+                    :disabled="passkeyLoading"
+                    @click="handleAuthenticate()"
+                >
+                    <LogIn :size="16" :stroke-width="1.5" />
+                    Sign in with existing passkey
+                </button>
+
+                <div v-if="error" class="text-xs text-accent text-center">{{ error }}</div>
+
+                <p v-if="passkeyLoading" class="text-xs text-muted text-center">
+                    Waiting for passkey...
+                </p>
+            </div>
+
+            <!-- ── Step 3: Success ── -->
+            <div v-else key="success" class="flex flex-col items-center gap-3 py-6">
+                <div class="success-icon-ring">
+                    <Fingerprint :size="28" class="text-correct" />
+                </div>
+                <h3 class="heading-section text-xl text-ink">{{ successMessage }}</h3>
+                <p class="text-sm text-muted">
+                    {{ isNewAccount ? 'Your passkey has been created.' : 'Signed in with your passkey.' }}
+                </p>
+            </div>
+        </Transition>
     </BaseModal>
 </template>
 
 <script setup lang="ts">
-import { Fingerprint, Mail } from 'lucide-vue-next';
+import { Fingerprint, Mail, ArrowLeft, UserPlus, LogIn } from 'lucide-vue-next';
 
-defineProps<{ visible: boolean }>();
+const props = defineProps<{ visible: boolean }>();
 const emit = defineEmits<{ close: [] }>();
 
 const { loginWithGoogle, refreshSession } = useAuth();
 
+type Step = 'main' | 'passkey' | 'success';
+const step = ref<Step>('main');
+const transitionName = ref('step-forward');
 const error = ref('');
 const passkeyLoading = ref(false);
 const passkeySupported = ref(false);
+const successMessage = ref('');
+const isNewAccount = ref(false);
 
-// Must be called at top level of setup, not inside async handlers
-const { authenticate, register } = useWebAuthn({
+const { authenticate, register, isPlatformAvailable } = useWebAuthn({
     authenticateEndpoint: '/api/webauthn/authenticate',
     registerEndpoint: '/api/webauthn/register',
 });
 
+// iPhone users get passkey first (Face ID is the native auth primitive);
+// everyone else gets Google first (path of least resistance on Android/desktop)
+const isIOS = ref(false);
+const authOrder = computed<Array<'google' | 'passkey'>>(() =>
+    isIOS.value ? ['passkey', 'google'] : ['google', 'passkey'],
+);
+
 if (import.meta.client) {
-    onMounted(() => {
-        passkeySupported.value = !!window.PublicKeyCredential;
+    onMounted(async () => {
+        isIOS.value = /iPhone|iPad|iPod/.test(navigator.userAgent);
+        if (!window.PublicKeyCredential) return;
+        passkeySupported.value = await isPlatformAvailable();
     });
 }
 
-async function handlePasskey() {
+// Reset state when modal opens/closes
+watch(
+    () => props.visible,
+    (isVisible) => {
+        if (isVisible) {
+            step.value = 'main';
+            transitionName.value = 'step-forward';
+            successMessage.value = '';
+            error.value = '';
+            passkeyLoading.value = false;
+        }
+    },
+);
+
+function goToPasskeyChoice() {
+    transitionName.value = 'step-forward';
+    error.value = '';
+    step.value = 'passkey';
+}
+
+function goBack() {
+    transitionName.value = 'step-back';
+    error.value = '';
+    step.value = 'main';
+}
+
+function handleClose() {
+    emit('close');
+}
+
+async function handleRegister() {
     error.value = '';
     passkeyLoading.value = true;
 
     try {
-        // Try discoverable credential authentication first
+        const { displayName } = await $fetch('/api/auth/generate-name');
+        await register({ userName: displayName, displayName });
+        await refreshSession();
+        isNewAccount.value = true;
+        successMessage.value = `Welcome, ${displayName}!`;
+        transitionName.value = 'step-success';
+        step.value = 'success';
+        setTimeout(() => emit('close'), 1500);
+    } catch (regErr: unknown) {
+        const msg =
+            (regErr as { data?: { message?: string }; message?: string })?.data?.message ||
+            (regErr as { message?: string })?.message ||
+            '';
+        if (!msg.includes('abort') && !msg.includes('cancel') && !msg.includes('NotAllowed')) {
+            error.value = msg || 'Failed to create passkey';
+        }
+    } finally {
+        passkeyLoading.value = false;
+    }
+}
+
+async function handleAuthenticate() {
+    error.value = '';
+    passkeyLoading.value = true;
+
+    try {
         await authenticate();
         await refreshSession();
-        emit('close');
+        isNewAccount.value = false;
+        successMessage.value = 'Welcome back!';
+        transitionName.value = 'step-success';
+        step.value = 'success';
+        setTimeout(() => emit('close'), 1500);
     } catch (authErr: unknown) {
         const msg =
             (authErr as { data?: { message?: string }; message?: string })?.data?.message ||
             (authErr as { message?: string })?.message ||
             '';
-
-        // User explicitly cancelled
-        if (msg.includes('abort') || msg.includes('cancel') || msg.includes('NotAllowed')) {
-            passkeyLoading.value = false;
-            return;
-        }
-
-        // No credential or wrong credential — auto-register a new account
-        // Fetch a name from the server so the browser prompt and the account match
-        try {
-            const { displayName } = await $fetch('/api/auth/generate-name');
-            await register({ userName: displayName, displayName });
-            await refreshSession();
-            emit('close');
-        } catch (regErr: unknown) {
-            const regMsg =
-                (regErr as { data?: { message?: string }; message?: string })?.data?.message ||
-                (regErr as { message?: string })?.message ||
-                '';
-            if (!regMsg.includes('abort') && !regMsg.includes('cancel')) {
-                error.value = regMsg || 'Failed to create passkey';
-            }
+        if (!msg.includes('abort') && !msg.includes('cancel') && !msg.includes('NotAllowed')) {
+            error.value = msg || 'Could not find a passkey for this site';
         }
     } finally {
         passkeyLoading.value = false;
     }
 }
 </script>
+
+<style scoped>
+/* ── Step transitions ── */
+
+/* Forward: content slides left */
+.step-forward-enter-active,
+.step-forward-leave-active {
+    transition: all 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.step-forward-enter-from {
+    opacity: 0;
+    transform: translateX(20px);
+}
+.step-forward-leave-to {
+    opacity: 0;
+    transform: translateX(-20px);
+}
+
+/* Back: content slides right */
+.step-back-enter-active,
+.step-back-leave-active {
+    transition: all 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.step-back-enter-from {
+    opacity: 0;
+    transform: translateX(-20px);
+}
+.step-back-leave-to {
+    opacity: 0;
+    transform: translateX(20px);
+}
+
+/* Success: gentle rise */
+.step-success-enter-active {
+    transition: all 300ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.step-success-leave-active {
+    transition: all 150ms ease;
+}
+.step-success-enter-from {
+    opacity: 0;
+    transform: translateY(8px);
+}
+.step-success-leave-to {
+    opacity: 0;
+}
+
+/* ── Success icon ring ── */
+
+.success-icon-ring {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    border: 2px solid var(--color-correct);
+    animation: success-appear 400ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes success-appear {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+</style>

--- a/components/app/AppShell.vue
+++ b/components/app/AppShell.vue
@@ -8,7 +8,7 @@
             :lang-code="lang"
             :language-name="langName"
             :is-rtl="isRtl"
-            :current-mode="currentMode"
+            :current-mode="currentMode ?? undefined"
             :ui="ui"
             @close="sidebarOpen = false"
             @select-mode="onSelectMode"

--- a/components/app/AppSidebar.vue
+++ b/components/app/AppSidebar.vue
@@ -240,11 +240,13 @@
                         icon="ChartNoAxesCombined"
                         :label="ui?.statistics || 'Statistics'"
                         href="/profile#statistics"
+                        @click="close()"
                     />
                     <SidebarItem
                         icon="Award"
                         :label="ui?.badges || 'Badges'"
                         href="/profile#badges"
+                        @click="close()"
                     />
                     <SidebarItem
                         icon="Settings"
@@ -254,19 +256,11 @@
                             close();
                         "
                     />
-                    <a
-                        :href="bugReportUrl"
-                        target="_blank"
-                        rel="noopener"
-                        class="sidebar-item w-full"
-                    >
-                        <span class="item-icon w-5 flex items-center justify-center">
-                            <Bug :size="18" class="text-current" />
-                        </span>
-                        <span class="text-sm text-ink">{{
-                            ui?.report_issue || 'Report a bug'
-                        }}</span>
-                    </a>
+                    <SidebarItem
+                        icon="Bug"
+                        :label="ui?.report_issue || 'Report a bug'"
+                        @click="openReportModal(); close()"
+                    />
                 </div>
 
                 <!-- Explore section -->
@@ -276,11 +270,13 @@
                         icon="Trophy"
                         label="Leaderboard"
                         :href="`/leaderboard?lang=${langCode}`"
+                        @click="close()"
                     />
                     <SidebarItem
                         icon="Calendar"
                         :label="ui?.archive || 'Archive'"
                         :href="`/${langCode}/archive`"
+                        @click="close()"
                     />
                 </div>
 
@@ -354,7 +350,6 @@ import {
     Globe,
     ChevronRight,
     ChevronDown,
-    Bug,
     Grid2x2,
     CalendarDays,
     Infinity as InfinityIcon,
@@ -399,6 +394,7 @@ const emit = defineEmits<{
 
 const { loggedIn, user, avatarUrl: authAvatarUrl, loginWithGoogle, logout } = useAuth();
 const { openLoginModal } = useLoginModal();
+const { openReportModal } = useReportModal();
 const route = useRoute();
 
 const sidebarEl = ref<HTMLElement | null>(null);
@@ -541,34 +537,6 @@ const disabledModes = computed(() =>
     GAME_MODES_UI.filter((m) => !m.enabled && m.id !== 'unlimited')
 );
 
-// Pre-fill bug report with language, mode, and device info
-const bugReportUrl = computed(() => {
-    const params = new URLSearchParams({
-        template: 'bug.yml',
-        labels: 'bug',
-        language: props.langCode || '',
-    });
-    if (import.meta.client) {
-        const ua = navigator.userAgent;
-        const platform = /iPhone|iPad/.test(ua)
-            ? 'iOS'
-            : /Android/.test(ua)
-              ? 'Android'
-              : /Mac/.test(ua)
-                ? 'Mac'
-                : /Windows/.test(ua)
-                  ? 'Windows'
-                  : 'Other';
-        params.set(
-            'device',
-            `${platform} / ${navigator.userAgent.split(') ').pop()?.split('/')[0] || 'Unknown'}`
-        );
-    }
-    if (props.currentMode && props.currentMode !== 'classic') {
-        params.set('title', `Bug in ${props.currentMode} mode (${props.langCode})`);
-    }
-    return `https://github.com/Hugo0/wordle/issues/new?${params}`;
-});
 </script>
 
 <style scoped>

--- a/components/app/AppSidebar.vue
+++ b/components/app/AppSidebar.vue
@@ -259,7 +259,10 @@
                     <SidebarItem
                         icon="Bug"
                         :label="ui?.report_issue || 'Report a bug'"
-                        @click="openReportModal(); close()"
+                        @click="
+                            openReportModal();
+                            close();
+                        "
                     />
                 </div>
 
@@ -536,7 +539,6 @@ const multiboardModes = computed(
 const disabledModes = computed(() =>
     GAME_MODES_UI.filter((m) => !m.enabled && m.id !== 'unlimited')
 );
-
 </script>
 
 <style scoped>

--- a/components/app/SidebarItem.vue
+++ b/components/app/SidebarItem.vue
@@ -4,7 +4,7 @@
         :to="href"
         class="sidebar-item w-full"
         :class="{ 'sidebar-item-active': active }"
-        @click="$emit('click')"
+        @click="handleClick"
     >
         <span class="item-icon w-5 text-center flex items-center justify-center">
             <component :is="iconComponent" :size="18" class="text-current" />
@@ -50,6 +50,7 @@
 import {
     Square,
     Infinity as InfinityIcon,
+    Bug,
     Columns2,
     Columns3,
     Grid2x2,
@@ -83,11 +84,27 @@ const props = withDefaults(
     }
 );
 
-defineEmits<{ click: [] }>();
+const emit = defineEmits<{ click: [] }>();
+
+const route = useRoute();
+
+function handleClick() {
+    emit('click');
+    // If the href has a hash and we're already on the same page, scroll to the element
+    if (props.href?.includes('#')) {
+        const [path, hash] = props.href.split('#');
+        if (route.path === path || (!path && route.hash === `#${hash}`)) {
+            nextTick(() => {
+                document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' });
+            });
+        }
+    }
+}
 
 const iconMap: Record<string, any> = {
     Square,
     Infinity: InfinityIcon,
+    Bug,
     Columns2,
     Columns3,
     Grid2x2,

--- a/components/game/MultiBoardLayout.vue
+++ b/components/game/MultiBoardLayout.vue
@@ -157,9 +157,9 @@ function onBoardClick(_boardIndex: number) {
 const containerRef = ref<HTMLElement | null>(null);
 const scrollRef = ref<HTMLElement | null>(null);
 // null until measured — grid hidden until we know the real size (no layout shift)
-const containerWidth = ref<number | null>(null);
+const containerWidth = ref<number>(0);
 const containerHeight = ref(600);
-const measured = computed(() => containerWidth.value !== null);
+const measured = computed(() => containerWidth.value > 0);
 
 let resizeObserver: ResizeObserver | null = null;
 

--- a/components/game/PageShell.vue
+++ b/components/game/PageShell.vue
@@ -178,7 +178,7 @@ const emit = defineEmits<{ toggleSidebar: []; closeSidebar: []; newGame: []; res
 const game = useGameStore();
 
 // Header flag icon
-const headerFlagSrc = computed(() => useFlag(props.lang));
+const headerFlagSrc = computed(() => useFlag(props.lang) ?? undefined);
 
 // Sub-panel: when subtitle is clicked, open sidebar WITH sub-panel visible
 const showSubPanelOnOpen = ref(false);

--- a/components/shared/BaseTooltip.vue
+++ b/components/shared/BaseTooltip.vue
@@ -125,8 +125,12 @@ onUnmounted(() => document.removeEventListener('click', onDocumentClick, true));
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 }
 
-.tooltip-box.above { bottom: calc(100% + 8px); }
-.tooltip-box.below { top: calc(100% + 8px); }
+.tooltip-box.above {
+    bottom: calc(100% + 8px);
+}
+.tooltip-box.below {
+    top: calc(100% + 8px);
+}
 
 .tooltip-caret {
     position: absolute;
@@ -148,11 +152,20 @@ onUnmounted(() => document.removeEventListener('click', onDocumentClick, true));
 
 .tt-enter-active,
 .tt-leave-active {
-    transition: opacity 120ms ease, transform 120ms ease;
+    transition:
+        opacity 120ms ease,
+        transform 120ms ease;
 }
-.tt-enter-from, .tt-leave-to { opacity: 0; }
+.tt-enter-from,
+.tt-leave-to {
+    opacity: 0;
+}
 .tooltip-box.above.tt-enter-from,
-.tooltip-box.above.tt-leave-to { transform: translateX(-50%) translateY(4px); }
+.tooltip-box.above.tt-leave-to {
+    transform: translateX(-50%) translateY(4px);
+}
 .tooltip-box.below.tt-enter-from,
-.tooltip-box.below.tt-leave-to { transform: translateX(-50%) translateY(-4px); }
+.tooltip-box.below.tt-leave-to {
+    transform: translateX(-50%) translateY(-4px);
+}
 </style>

--- a/components/shared/BaseTooltip.vue
+++ b/components/shared/BaseTooltip.vue
@@ -1,0 +1,158 @@
+<!--
+    BaseTooltip — editorial tooltip with auto-positioning.
+
+    Shows on hover (desktop) and tap (mobile). Positions above or below
+    based on viewport space. Constrained to screen width on mobile.
+-->
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+
+defineProps<{
+    text?: string;
+}>();
+
+const triggerRef = ref<HTMLElement | null>(null);
+const tooltipRef = ref<HTMLElement | null>(null);
+const visible = ref(false);
+const position = ref<'above' | 'below'>('above');
+
+function updatePosition() {
+    if (!triggerRef.value) return;
+    const rect = triggerRef.value.getBoundingClientRect();
+    position.value = rect.top < 160 ? 'below' : 'above';
+
+    // Constrain horizontally to viewport on mobile
+    if (tooltipRef.value) {
+        const tip = tooltipRef.value;
+        const tipRect = tip.getBoundingClientRect();
+        if (tipRect.right > window.innerWidth - 8) {
+            tip.style.left = 'auto';
+            tip.style.right = `-${rect.right - window.innerWidth + 8}px`;
+            tip.style.transform = 'none';
+        } else if (tipRect.left < 8) {
+            tip.style.left = `-${rect.left - 8}px`;
+            tip.style.transform = 'none';
+        }
+    }
+}
+
+function show() {
+    visible.value = true;
+    requestAnimationFrame(() => updatePosition());
+}
+
+function hide() {
+    visible.value = false;
+    if (tooltipRef.value) {
+        tooltipRef.value.style.left = '';
+        tooltipRef.value.style.right = '';
+        tooltipRef.value.style.transform = '';
+    }
+}
+
+function toggle(e: Event) {
+    e.stopPropagation();
+    visible.value ? hide() : show();
+}
+
+function onDocumentClick(e: MouseEvent) {
+    if (
+        !triggerRef.value?.contains(e.target as Node) &&
+        !tooltipRef.value?.contains(e.target as Node)
+    ) {
+        hide();
+    }
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick, true));
+onUnmounted(() => document.removeEventListener('click', onDocumentClick, true));
+</script>
+
+<template>
+    <span
+        ref="triggerRef"
+        class="tooltip-trigger"
+        @mouseenter="show"
+        @mouseleave="hide"
+        @click="toggle"
+    >
+        <slot />
+        <Transition name="tt">
+            <span
+                v-if="visible && (text || $slots.content)"
+                ref="tooltipRef"
+                class="tooltip-box"
+                :class="position"
+                role="tooltip"
+            >
+                <span class="tooltip-caret" />
+                <slot name="content">
+                    <span>{{ text }}</span>
+                </slot>
+            </span>
+        </Transition>
+    </span>
+</template>
+
+<style scoped>
+.tooltip-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: help;
+}
+
+.tooltip-box {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: min(280px, calc(100vw - 24px));
+    width: max-content;
+    padding: 10px 14px;
+    /* Inverted: ink bg, paper text — high contrast in both modes */
+    background: var(--color-ink);
+    color: var(--color-paper);
+    font-family: var(--font-body);
+    font-size: 12px;
+    line-height: 1.55;
+    letter-spacing: 0;
+    text-transform: none;
+    text-align: left;
+    border: none;
+    z-index: 200;
+    pointer-events: none;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.tooltip-box.above { bottom: calc(100% + 8px); }
+.tooltip-box.below { top: calc(100% + 8px); }
+
+.tooltip-caret {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+}
+.tooltip-box.above .tooltip-caret {
+    bottom: -5px;
+    border-top: 5px solid var(--color-ink);
+}
+.tooltip-box.below .tooltip-caret {
+    top: -5px;
+    border-bottom: 5px solid var(--color-ink);
+}
+
+.tt-enter-active,
+.tt-leave-active {
+    transition: opacity 120ms ease, transform 120ms ease;
+}
+.tt-enter-from, .tt-leave-to { opacity: 0; }
+.tooltip-box.above.tt-enter-from,
+.tooltip-box.above.tt-leave-to { transform: translateX(-50%) translateY(4px); }
+.tooltip-box.below.tt-enter-from,
+.tooltip-box.below.tt-leave-to { transform: translateX(-50%) translateY(-4px); }
+</style>

--- a/components/shared/ReportModal.vue
+++ b/components/shared/ReportModal.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { Bug, MessageSquare, Send, CheckCircle } from 'lucide-vue-next';
+
+const props = defineProps<{ visible: boolean }>();
+const emit = defineEmits<{ close: [] }>();
+
+const reportType = ref<'bug' | 'feedback'>('bug');
+const message = ref('');
+const sending = ref(false);
+const sent = ref(false);
+const error = ref('');
+
+const route = useRoute();
+const { showToast } = useToast();
+
+// Auto-collect context (client-only, safe defaults)
+function collectContext() {
+    if (!import.meta.client) return {};
+    const isPwa =
+        window.matchMedia('(display-mode: standalone)').matches ||
+        (navigator as any).standalone === true;
+    return {
+        url: window.location.href,
+        lang: route.params.lang as string || undefined,
+        mode: route.params.mode as string || route.query.mode as string || undefined,
+        userAgent: navigator.userAgent,
+        screenSize: `${window.innerWidth}x${window.innerHeight}`,
+        isPwa,
+    };
+}
+
+async function submit() {
+    const trimmed = message.value.trim();
+    if (trimmed.length < 5) {
+        error.value = 'Please write a bit more so we can understand the issue.';
+        return;
+    }
+
+    sending.value = true;
+    error.value = '';
+
+    try {
+        await $fetch('/api/report', {
+            method: 'POST',
+            body: {
+                type: reportType.value,
+                message: trimmed,
+                ...collectContext(),
+            },
+        });
+        sent.value = true;
+    } catch (e: any) {
+        if (e.statusCode === 429) {
+            error.value = 'Too many reports — please try again later.';
+        } else {
+            error.value = 'Something went wrong. Please try again.';
+        }
+    } finally {
+        sending.value = false;
+    }
+}
+
+function handleClose() {
+    if (sent.value) {
+        showToast('Report sent — thank you!');
+    }
+    // Reset state for next open
+    message.value = '';
+    sent.value = false;
+    error.value = '';
+    reportType.value = 'bug';
+    emit('close');
+}
+
+// Reset on re-open
+watch(() => props.visible, (open) => {
+    if (open) {
+        sent.value = false;
+        error.value = '';
+    }
+});
+</script>
+
+<template>
+    <BaseModal :visible="visible" size="sm" @close="handleClose">
+        <!-- Success state -->
+        <div v-if="sent" class="flex flex-col items-center gap-3 py-6 text-center">
+            <CheckCircle :size="36" class="text-correct" />
+            <h3 class="heading-section text-lg text-ink">Report received</h3>
+            <p class="text-sm text-muted max-w-[240px]">
+                Thanks for helping improve Wordle Global. We'll look into this.
+            </p>
+            <button
+                class="mt-2 px-5 py-2 bg-ink text-paper text-sm font-semibold transition-opacity hover:opacity-85 cursor-pointer"
+                @click="handleClose"
+            >
+                Done
+            </button>
+        </div>
+
+        <!-- Form state -->
+        <template v-else>
+            <h3 class="heading-section text-xl text-ink">Report an issue</h3>
+            <p class="text-sm text-muted mt-1 mb-4">
+                Found a bug or have feedback? Let us know.
+            </p>
+
+            <!-- Type toggle -->
+            <div class="flex gap-2 mb-4">
+                <button
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold border transition-colors cursor-pointer"
+                    :class="reportType === 'bug'
+                        ? 'bg-ink text-paper border-ink'
+                        : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'"
+                    @click="reportType = 'bug'"
+                >
+                    <Bug :size="14" />
+                    Bug
+                </button>
+                <button
+                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold border transition-colors cursor-pointer"
+                    :class="reportType === 'feedback'
+                        ? 'bg-ink text-paper border-ink'
+                        : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'"
+                    @click="reportType = 'feedback'"
+                >
+                    <MessageSquare :size="14" />
+                    Feedback
+                </button>
+            </div>
+
+            <!-- Message -->
+            <textarea
+                v-model="message"
+                :placeholder="reportType === 'bug'
+                    ? 'What happened? What did you expect to happen?'
+                    : 'What would you like to see changed or added?'"
+                class="w-full h-32 px-3 py-2.5 text-sm text-ink bg-paper border border-rule placeholder:text-muted/50 resize-none focus:outline-none focus:border-ink transition-colors editorial-scroll"
+                maxlength="2000"
+                :disabled="sending"
+                @keydown.meta.enter="submit"
+                @keydown.ctrl.enter="submit"
+            />
+            <div class="flex items-center justify-between mt-1 mb-3">
+                <div v-if="error" class="text-xs text-accent">{{ error }}</div>
+                <div v-else class="text-[10px] text-muted/50">
+                    Page URL, browser, and screen size are sent automatically.
+                </div>
+                <div class="text-[10px] text-muted/40 ml-auto">
+                    {{ message.length }}/2000
+                </div>
+            </div>
+
+            <button
+                class="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-ink text-paper text-sm font-semibold transition-opacity hover:opacity-85 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                :disabled="sending || message.trim().length < 5"
+                @click="submit"
+            >
+                <Send :size="14" />
+                {{ sending ? 'Sending…' : 'Send report' }}
+            </button>
+        </template>
+    </BaseModal>
+</template>

--- a/components/shared/ReportModal.vue
+++ b/components/shared/ReportModal.vue
@@ -21,8 +21,8 @@ function collectContext() {
         (navigator as any).standalone === true;
     return {
         url: window.location.href,
-        lang: route.params.lang as string || undefined,
-        mode: route.params.mode as string || route.query.mode as string || undefined,
+        lang: (route.params.lang as string) || undefined,
+        mode: (route.params.mode as string) || (route.query.mode as string) || undefined,
         userAgent: navigator.userAgent,
         screenSize: `${window.innerWidth}x${window.innerHeight}`,
         isPwa,
@@ -73,12 +73,15 @@ function handleClose() {
 }
 
 // Reset on re-open
-watch(() => props.visible, (open) => {
-    if (open) {
-        sent.value = false;
-        error.value = '';
+watch(
+    () => props.visible,
+    (open) => {
+        if (open) {
+            sent.value = false;
+            error.value = '';
+        }
     }
-});
+);
 </script>
 
 <template>
@@ -101,17 +104,17 @@ watch(() => props.visible, (open) => {
         <!-- Form state -->
         <template v-else>
             <h3 class="heading-section text-xl text-ink">Report an issue</h3>
-            <p class="text-sm text-muted mt-1 mb-4">
-                Found a bug or have feedback? Let us know.
-            </p>
+            <p class="text-sm text-muted mt-1 mb-4">Found a bug or have feedback? Let us know.</p>
 
             <!-- Type toggle -->
             <div class="flex gap-2 mb-4">
                 <button
                     class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold border transition-colors cursor-pointer"
-                    :class="reportType === 'bug'
-                        ? 'bg-ink text-paper border-ink'
-                        : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'"
+                    :class="
+                        reportType === 'bug'
+                            ? 'bg-ink text-paper border-ink'
+                            : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'
+                    "
                     @click="reportType = 'bug'"
                 >
                     <Bug :size="14" />
@@ -119,9 +122,11 @@ watch(() => props.visible, (open) => {
                 </button>
                 <button
                     class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold border transition-colors cursor-pointer"
-                    :class="reportType === 'feedback'
-                        ? 'bg-ink text-paper border-ink'
-                        : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'"
+                    :class="
+                        reportType === 'feedback'
+                            ? 'bg-ink text-paper border-ink'
+                            : 'bg-transparent text-muted border-rule hover:border-ink hover:text-ink'
+                    "
                     @click="reportType = 'feedback'"
                 >
                     <MessageSquare :size="14" />
@@ -132,9 +137,11 @@ watch(() => props.visible, (open) => {
             <!-- Message -->
             <textarea
                 v-model="message"
-                :placeholder="reportType === 'bug'
-                    ? 'What happened? What did you expect to happen?'
-                    : 'What would you like to see changed or added?'"
+                :placeholder="
+                    reportType === 'bug'
+                        ? 'What happened? What did you expect to happen?'
+                        : 'What would you like to see changed or added?'
+                "
                 class="w-full h-32 px-3 py-2.5 text-sm text-ink bg-paper border border-rule placeholder:text-muted/50 resize-none focus:outline-none focus:border-ink transition-colors editorial-scroll"
                 maxlength="2000"
                 :disabled="sending"
@@ -146,9 +153,7 @@ watch(() => props.visible, (open) => {
                 <div v-else class="text-[10px] text-muted/50">
                     Page URL, browser, and screen size are sent automatically.
                 </div>
-                <div class="text-[10px] text-muted/40 ml-auto">
-                    {{ message.length }}/2000
-                </div>
+                <div class="text-[10px] text-muted/40 ml-auto">{{ message.length }}/2000</div>
             </div>
 
             <button

--- a/components/shared/StreakCalendar.vue
+++ b/components/shared/StreakCalendar.vue
@@ -186,11 +186,11 @@ const calendarDays = computed<CalendarDay[]>(() => {
 
         let state: CalendarDay['state'];
         if (isToday) {
-            state = detail?.state;
+            state = detail?.state ?? 'today';
         } else if (isFuture) {
             state = 'future';
         } else {
-            state = detail?.state;
+            state = detail?.state ?? 'missed';
         }
 
         days.push({

--- a/components/word/NearbyInMeaning.vue
+++ b/components/word/NearbyInMeaning.vue
@@ -22,7 +22,9 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import { Info } from 'lucide-vue-next';
 import MeaningMap, { type MapDot } from '~/components/shared/MeaningMap.vue';
+import BaseTooltip from '~/components/shared/BaseTooltip.vue';
 import AddCompareWord from './AddCompareWord.vue';
 import MapFrame from '~/components/shared/MapFrame.vue';
 import type { WordData } from '~/composables/useWordData';
@@ -278,7 +280,26 @@ const canShowMap = computed(() => mapDots.value.length >= 1);
 
 <template>
     <section v-if="canShowMap" class="nearby">
-        <div class="section-label">Nearby in Meaning</div>
+        <div class="section-label">
+            Nearby in Meaning
+            <BaseTooltip>
+                <Info :size="13" class="info-icon" />
+                <template #content>
+                    <span class="tooltip-body">
+                        Words that mean similar things appear close together.
+                        Red lines connect the most closely related words.
+                        Brighter, larger dots indicate stronger similarity.
+                        <br /><br />
+                        The map is a simplified 2D view of how words relate
+                        in meaning — originally computed across hundreds of
+                        dimensions. Click any word to explore its neighborhood.
+                        <br /><br />
+                        The "slice by" chips let you compare words along specific
+                        dimensions, like formal vs. informal or concrete vs. abstract.
+                    </span>
+                </template>
+            </BaseTooltip>
+        </div>
 
         <div class="map-wrap">
             <MapFrame
@@ -387,6 +408,24 @@ const canShowMap = computed(() => mapDots.value.length >= 1);
     flex-direction: column;
     gap: 20px;
     padding: 8px 0;
+}
+
+.info-icon {
+    color: var(--color-muted);
+    vertical-align: middle;
+    margin-left: 4px;
+    cursor: help;
+    transition: color 120ms ease;
+}
+.info-icon:hover {
+    color: var(--color-ink);
+}
+
+.tooltip-body {
+    font-family: var(--font-body);
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--color-paper);
 }
 
 .map-wrap {

--- a/components/word/NearbyInMeaning.vue
+++ b/components/word/NearbyInMeaning.vue
@@ -286,16 +286,16 @@ const canShowMap = computed(() => mapDots.value.length >= 1);
                 <Info :size="13" class="info-icon" />
                 <template #content>
                     <span class="tooltip-body">
-                        Words that mean similar things appear close together.
-                        Red lines connect the most closely related words.
-                        Brighter, larger dots indicate stronger similarity.
+                        Words that mean similar things appear close together. Red lines connect the
+                        most closely related words. Brighter, larger dots indicate stronger
+                        similarity.
                         <br /><br />
-                        The map is a simplified 2D view of how words relate
-                        in meaning — originally computed across hundreds of
-                        dimensions. Click any word to explore its neighborhood.
+                        The map is a simplified 2D view of how words relate in meaning — originally
+                        computed across hundreds of dimensions. Click any word to explore its
+                        neighborhood.
                         <br /><br />
-                        The "slice by" chips let you compare words along specific
-                        dimensions, like formal vs. informal or concrete vs. abstract.
+                        The "slice by" chips let you compare words along specific dimensions, like
+                        formal vs. informal or concrete vs. abstract.
                     </span>
                 </template>
             </BaseTooltip>

--- a/components/word/WordComments.vue
+++ b/components/word/WordComments.vue
@@ -1,0 +1,542 @@
+<script setup lang="ts">
+/**
+ * WordComments — native comment section replacing Giscus.
+ *
+ * Flat list, no threading. Auth required to post, public to read.
+ * Badges auto-populated from Results table via real-time SQL join.
+ */
+import { Send } from 'lucide-vue-next';
+import { GAME_MODE_CONFIG } from '~/utils/game-modes';
+import type { GameMode } from '~/utils/game-modes';
+
+interface Badge {
+    mode: string;
+    attempts: number;
+    won: boolean;
+}
+
+interface Appearance {
+    mode: string;
+    dayIdx: number;
+}
+
+const props = defineProps<{
+    targetType: string;
+    targetKey: string;
+    /** Language code for result lookups */
+    lang?: string;
+    /** Word appearances — used to look up game results for badges */
+    appearances?: Appearance[];
+}>();
+
+const { loggedIn, user } = useAuth();
+const { openLoginModal } = useLoginModal();
+const { showToast } = useToast();
+
+// Serialize appearances for API query param: "classic:1756,quordle:42"
+const appearancesParam = computed(() =>
+    (props.appearances ?? []).map((a) => `${a.mode}:${a.dayIdx}`).join(',')
+);
+
+// ── Fetch comments ─────────────────────────────────────────────────────
+interface CommentEntry {
+    id: string;
+    body: string;
+    username: string;
+    avatarUrl: string | null;
+    createdAt: string;
+    badges: Badge[];
+}
+
+const {
+    data: commentData,
+} = await useFetch<{ comments: CommentEntry[]; total: number; hasMore: boolean }>(
+    '/api/comments',
+    {
+        query: {
+            targetType: props.targetType,
+            targetKey: props.targetKey,
+            lang: props.lang || '',
+            appearances: appearancesParam,
+        },
+        watch: [() => props.targetKey],
+        default: () => ({ comments: [], total: 0, hasMore: false }),
+    },
+);
+
+const comments = computed(() => commentData.value?.comments ?? []);
+const total = computed(() => commentData.value?.total ?? 0);
+const displayComments = computed(() => [...comments.value].reverse());
+
+// ── Post comment ───────────────────────────────────────────────────────
+const draft = ref('');
+const posting = ref(false);
+const error = ref('');
+
+const canPost = computed(() => draft.value.trim().length >= 1 && !posting.value);
+
+async function postComment() {
+    if (!canPost.value) return;
+
+    posting.value = true;
+    error.value = '';
+
+    try {
+        const newComment = await $fetch<CommentEntry>('/api/comments', {
+            method: 'POST',
+            body: {
+                targetType: props.targetType,
+                targetKey: props.targetKey,
+                body: draft.value.trim(),
+                lang: props.lang || '',
+                appearances: appearancesParam.value,
+            },
+        });
+        commentData.value!.comments.unshift(newComment);
+        commentData.value!.total++;
+        draft.value = '';
+    } catch (e: any) {
+        const msg = e.data?.message || e.statusMessage || 'Failed to post comment.';
+        if (e.statusCode === 422) {
+            error.value = msg;
+        } else if (e.statusCode === 429) {
+            error.value = 'Slow down — try again in a few minutes.';
+        } else {
+            error.value = msg;
+        }
+    } finally {
+        posting.value = false;
+    }
+}
+
+// ── Badge formatting ───────────────────────────────────────────────────
+function badgeText(badge: Badge): string {
+    if (badge.mode === 'semantic') {
+        return `${badge.attempts} guesses`;
+    }
+    const config = GAME_MODE_CONFIG[badge.mode as GameMode];
+    const maxGuesses = config?.maxGuesses ?? 6;
+    return badge.won ? `${badge.attempts}/${maxGuesses}` : `X/${maxGuesses}`;
+}
+
+function badgeLabel(badge: Badge, allBadges: Badge[]): string | null {
+    if (allBadges.length <= 1) return null;
+    const config = GAME_MODE_CONFIG[badge.mode as GameMode];
+    return config?.label ?? badge.mode;
+}
+
+// ── Relative time ──────────────────────────────────────────────────────
+function relativeTime(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    if (days < 7) return `${days}d ago`;
+    return new Date(iso).toLocaleDateString();
+}
+
+// Auto-resize textarea
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+function autoResize() {
+    const el = textareaRef.value;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = el.scrollHeight + 'px';
+}
+
+const userInitial = computed(() =>
+    (user.value?.displayName ?? user.value?.email ?? '?').charAt(0).toUpperCase()
+);
+</script>
+
+<template>
+    <section class="comments-section">
+        <div class="comments-header">
+            <div class="section-label">Discussion</div>
+            <div v-if="total > 0" class="comments-count">
+                {{ total }} {{ total === 1 ? 'comment' : 'comments' }}
+            </div>
+        </div>
+
+        <!-- Comment list (newest last for reading order) -->
+        <div v-if="comments.length > 0" class="comments-list">
+            <div
+                v-for="c in displayComments"
+                :key="c.id"
+                class="comment-item"
+            >
+                <div class="comment-meta">
+                    <img
+                        v-if="c.avatarUrl"
+                        :src="c.avatarUrl"
+                        :alt="c.username"
+                        class="comment-avatar"
+                        referrerpolicy="no-referrer"
+                    />
+                    <div v-else class="comment-avatar-fallback">
+                        {{ c.username.charAt(0).toUpperCase() }}
+                    </div>
+                    <span class="comment-author">{{ c.username }}</span>
+                    <!-- Badges -->
+                    <template v-if="c.badges?.length">
+                        <span
+                            v-for="b in c.badges"
+                            :key="b.mode"
+                            class="comment-badge"
+                            :class="b.won ? 'badge-won' : 'badge-lost'"
+                        >
+                            <span v-if="c.badges.length > 1" class="badge-mode">{{ badgeLabel(b, c.badges) }}</span>
+                            {{ badgeText(b) }}
+                        </span>
+                    </template>
+                    <span class="comment-dot">&middot;</span>
+                    <span class="comment-time">{{ relativeTime(c.createdAt) }}</span>
+                </div>
+                <div class="comment-body">{{ c.body }}</div>
+            </div>
+        </div>
+
+        <!-- Empty state: merge with sign-in when not logged in -->
+        <div v-else class="comments-empty">
+            <div class="comments-empty-icon" />
+            <div class="comments-empty-title">No comments yet</div>
+            <div v-if="loggedIn" class="comments-empty-subtitle">
+                Be the first to share your thoughts on this word
+            </div>
+            <button v-else class="comments-signin-btn" style="margin-top: 8px" @click="openLoginModal()">
+                Sign in to comment
+            </button>
+        </div>
+
+        <!-- Input area (signed in) -->
+        <div v-if="loggedIn" class="comment-input-section">
+            <div class="comment-input-row">
+                <img
+                    v-if="user?.avatarUrl"
+                    :src="user.avatarUrl"
+                    alt=""
+                    class="comment-avatar"
+                    referrerpolicy="no-referrer"
+                />
+                <div v-else class="comment-avatar-fallback comment-avatar-you">
+                    {{ userInitial }}
+                </div>
+                <textarea
+                    ref="textareaRef"
+                    v-model="draft"
+                    class="comment-textarea"
+                    rows="1"
+                    placeholder="Add to the discussion..."
+                    maxlength="500"
+                    :disabled="posting"
+                    @input="autoResize"
+                    @keydown.meta.enter="postComment"
+                    @keydown.ctrl.enter="postComment"
+                />
+            </div>
+            <div v-if="error" class="comment-error">{{ error }}</div>
+            <div class="comment-input-footer">
+                <span class="comment-charcount">{{ draft.length }}/500</span>
+                <button
+                    class="comment-submit"
+                    :disabled="!canPost"
+                    @click="postComment"
+                >
+                    <Send :size="12" />
+                    {{ posting ? 'Posting...' : 'Post' }}
+                </button>
+            </div>
+        </div>
+
+        <!-- Guest prompt: only when there are comments to read but user can't post -->
+        <div v-else-if="comments.length" class="comments-guest-prompt">
+            <div class="comments-guest-text">Sign in to join the discussion</div>
+            <button class="comments-signin-btn" @click="openLoginModal()">Sign in</button>
+        </div>
+    </section>
+</template>
+
+<style scoped>
+.comments-section {
+    max-width: 640px;
+    margin: 0 auto;
+}
+
+.comments-header {
+    margin-bottom: 24px;
+}
+
+.comments-count {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    color: var(--color-muted);
+    text-align: center;
+    margin-top: 10px;
+}
+
+/* ─── Comment List ─── */
+.comments-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.comment-item {
+    padding: 16px 0;
+    border-bottom: 1px solid var(--color-rule);
+}
+.comment-item:last-child {
+    border-bottom: none;
+}
+
+.comment-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
+.comment-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+.comment-avatar-fallback {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--color-rule);
+    color: var(--color-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 12px;
+    flex-shrink: 0;
+}
+.comment-avatar-you {
+    background: var(--color-correct-soft);
+    color: var(--color-correct);
+}
+
+.comment-author {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--color-ink);
+}
+
+/* ─── Badges ─── */
+.comment-badge {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    padding: 1px 6px;
+    border: 1px solid;
+}
+.badge-won {
+    color: var(--color-correct);
+    border-color: var(--color-correct-soft);
+    background: var(--color-correct-soft);
+}
+.badge-lost {
+    color: var(--color-accent);
+    border-color: var(--color-accent-soft);
+    background: var(--color-accent-soft);
+}
+.badge-mode {
+    font-weight: 400;
+    opacity: 0.7;
+    margin-right: 2px;
+}
+
+.comment-time {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+}
+
+.comment-dot {
+    color: var(--color-rule);
+    font-size: 10px;
+}
+
+.comment-body {
+    font-family: var(--font-body);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--color-ink);
+    padding-inline-start: 38px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+/* ─── Input ─── */
+.comment-input-section {
+    margin-top: 4px;
+    padding-top: 20px;
+    border-top: 1px solid var(--color-rule);
+}
+
+.comment-input-row {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+}
+
+.comment-textarea {
+    flex: 1;
+    font-family: var(--font-body);
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--color-ink);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--color-rule);
+    padding: 6px 0;
+    resize: none;
+    outline: none;
+    min-height: 36px;
+    transition: border-color 150ms;
+}
+.comment-textarea::placeholder {
+    color: var(--color-muted);
+    opacity: 0.6;
+}
+.comment-textarea:focus {
+    border-bottom-color: var(--color-ink);
+}
+
+.comment-error {
+    font-size: 12px;
+    color: var(--color-accent);
+    padding-inline-start: 38px;
+    margin-top: 6px;
+}
+
+.comment-input-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 10px;
+    padding-inline-start: 38px;
+}
+
+.comment-charcount {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-muted);
+    opacity: 0.5;
+}
+
+.comment-submit {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 7px 16px;
+    background: var(--color-ink);
+    color: var(--color-paper);
+    border: 1px solid var(--color-ink);
+    cursor: pointer;
+    transition: opacity 120ms;
+}
+.comment-submit:hover:not(:disabled) {
+    opacity: 0.85;
+}
+.comment-submit:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+/* ─── Empty State ─── */
+.comments-empty {
+    text-align: center;
+    padding: 32px 0;
+}
+
+.comments-empty-icon {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    border: 1.5px solid var(--color-rule);
+    border-radius: 50%;
+    margin-bottom: 14px;
+    position: relative;
+}
+.comments-empty-icon::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    width: 8px;
+    height: 8px;
+    border-right: 1.5px solid var(--color-rule);
+    border-bottom: 1.5px solid var(--color-rule);
+    background: var(--color-paper);
+}
+
+.comments-empty-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-variation-settings: 'opsz' 48;
+    font-size: 16px;
+    color: var(--color-ink);
+    margin-bottom: 4px;
+}
+
+.comments-empty-subtitle {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: 'opsz' 20;
+    font-size: 13px;
+    color: var(--color-muted);
+}
+
+/* ─── Guest Prompt ─── */
+.comments-guest-prompt {
+    text-align: center;
+    padding: 20px 0 4px;
+    border-top: 1px solid var(--color-rule);
+    margin-top: 4px;
+}
+
+.comments-guest-text {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-variation-settings: 'opsz' 20;
+    font-size: 13px;
+    color: var(--color-muted);
+    margin-bottom: 12px;
+}
+
+.comments-signin-btn {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 8px 20px;
+    background: transparent;
+    color: var(--color-muted);
+    border: 1px solid var(--color-rule);
+    cursor: pointer;
+    transition: all 120ms;
+}
+.comments-signin-btn:hover {
+    color: var(--color-ink);
+    border-color: var(--color-ink);
+}
+</style>

--- a/components/word/WordComments.vue
+++ b/components/word/WordComments.vue
@@ -48,21 +48,20 @@ interface CommentEntry {
     badges: Badge[];
 }
 
-const {
-    data: commentData,
-} = await useFetch<{ comments: CommentEntry[]; total: number; hasMore: boolean }>(
-    '/api/comments',
-    {
-        query: {
-            targetType: props.targetType,
-            targetKey: props.targetKey,
-            lang: props.lang || '',
-            appearances: appearancesParam,
-        },
-        watch: [() => props.targetKey],
-        default: () => ({ comments: [], total: 0, hasMore: false }),
+const { data: commentData } = await useFetch<{
+    comments: CommentEntry[];
+    total: number;
+    hasMore: boolean;
+}>('/api/comments', {
+    query: {
+        targetType: props.targetType,
+        targetKey: props.targetKey,
+        lang: props.lang || '',
+        appearances: appearancesParam,
     },
-);
+    watch: [() => props.targetKey],
+    default: () => ({ comments: [], total: 0, hasMore: false }),
+});
 
 const comments = computed(() => commentData.value?.comments ?? []);
 const total = computed(() => commentData.value?.total ?? 0);
@@ -163,11 +162,7 @@ const userInitial = computed(() =>
 
         <!-- Comment list (newest last for reading order) -->
         <div v-if="comments.length > 0" class="comments-list">
-            <div
-                v-for="c in displayComments"
-                :key="c.id"
-                class="comment-item"
-            >
+            <div v-for="c in displayComments" :key="c.id" class="comment-item">
                 <div class="comment-meta">
                     <img
                         v-if="c.avatarUrl"
@@ -188,7 +183,9 @@ const userInitial = computed(() =>
                             class="comment-badge"
                             :class="b.won ? 'badge-won' : 'badge-lost'"
                         >
-                            <span v-if="c.badges.length > 1" class="badge-mode">{{ badgeLabel(b, c.badges) }}</span>
+                            <span v-if="c.badges.length > 1" class="badge-mode">{{
+                                badgeLabel(b, c.badges)
+                            }}</span>
                             {{ badgeText(b) }}
                         </span>
                     </template>
@@ -206,7 +203,12 @@ const userInitial = computed(() =>
             <div v-if="loggedIn" class="comments-empty-subtitle">
                 Be the first to share your thoughts on this word
             </div>
-            <button v-else class="comments-signin-btn" style="margin-top: 8px" @click="openLoginModal()">
+            <button
+                v-else
+                class="comments-signin-btn"
+                style="margin-top: 8px"
+                @click="openLoginModal()"
+            >
                 Sign in to comment
             </button>
         </div>
@@ -240,11 +242,7 @@ const userInitial = computed(() =>
             <div v-if="error" class="comment-error">{{ error }}</div>
             <div class="comment-input-footer">
                 <span class="comment-charcount">{{ draft.length }}/500</span>
-                <button
-                    class="comment-submit"
-                    :disabled="!canPost"
-                    @click="postComment"
-                >
+                <button class="comment-submit" :disabled="!canPost" @click="postComment">
                     <Send :size="12" />
                     {{ posting ? 'Posting...' : 'Post' }}
                 </button>

--- a/components/word/WordDictionary.vue
+++ b/components/word/WordDictionary.vue
@@ -120,11 +120,7 @@ function formatTags(tags: string[]): string {
                         <span class="sense-gloss">{{ sense.gloss }}</span>
 
                         <div v-if="sense.examples?.length" class="examples">
-                            <div
-                                v-for="(ex, exi) in sense.examples"
-                                :key="exi"
-                                class="example"
-                            >
+                            <div v-for="(ex, exi) in sense.examples" :key="exi" class="example">
                                 <span class="example-text">&ldquo;{{ ex.text }}&rdquo;</span>
                                 <span v-if="ex.translation" class="example-translation">
                                     — {{ ex.translation }}
@@ -141,7 +137,9 @@ function formatTags(tags: string[]): string {
                 <span class="forms-list">
                     <span v-for="(f, fi) in data.forms" :key="fi" class="form-item">
                         <em>{{ f.form }}</em>
-                        <span v-if="f.tags.length" class="form-tags">({{ f.tags.join(', ') }})</span>
+                        <span v-if="f.tags.length" class="form-tags"
+                            >({{ f.tags.join(', ') }})</span
+                        >
                         <span v-if="fi < data.forms!.length - 1" class="form-sep"> · </span>
                     </span>
                 </span>
@@ -158,9 +156,7 @@ function formatTags(tags: string[]): string {
                 >
                     Wiktionary — CC BY-SA 4.0
                 </a>
-                <span v-else class="attribution-link">
-                    Source: Wiktionary — CC BY-SA 4.0
-                </span>
+                <span v-else class="attribution-link"> Source: Wiktionary — CC BY-SA 4.0 </span>
             </div>
         </div>
     </section>

--- a/components/word/WordDictionary.vue
+++ b/components/word/WordDictionary.vue
@@ -1,0 +1,360 @@
+<!--
+    WordDictionary — full dictionary entry from Wiktionary/kaikki data.
+
+    Renders structured dictionary content: multiple senses with numbered
+    glosses, part of speech headers, etymology, IPA pronunciation, and
+    usage examples. Gracefully degrades when fields are missing — shows
+    whatever's available without skeleton blocks or "no data" messages.
+
+    Data quality varies by language:
+      - Rich (en, de, fr, es): multiple senses, etymology, IPA, examples
+      - Medium (it, pt, nl, sv): senses + some etymology
+      - Sparse (small languages): single gloss only, or nothing
+
+    For sparse data, the parent page's inline WordDefinition component
+    already covers the basics — this section only renders when there's
+    richer data worth showing (multiple senses, etymology, or examples).
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface DictionaryGloss {
+    gloss: string;
+    examples?: Array<{ text: string; translation?: string }>;
+    tags?: string[];
+    synonyms?: string[];
+}
+
+export interface DictionaryEntry {
+    pos: string;
+    glosses: DictionaryGloss[];
+}
+
+export interface DictionaryData {
+    word: string;
+    entries: DictionaryEntry[];
+    etymology?: string;
+    pronunciation?: string;
+    forms?: Array<{ form: string; tags: string[] }>;
+}
+
+const props = defineProps<{
+    data: DictionaryData;
+    wiktionaryUrl?: string | null;
+    /** Collapse by default (for daily word pages where user came for the game) */
+    collapsed?: boolean;
+}>();
+
+const expanded = ref(!props.collapsed);
+
+/** Merge duplicate POS entries (kaikki sometimes has multiple "noun" sections
+ *  for different etymology numbers) and drop entries with no senses. */
+const mergedEntries = computed(() => {
+    const byPos = new Map<string, DictionaryEntry>();
+    for (const entry of props.data.entries) {
+        if (!entry.glosses.length) continue;
+        const existing = byPos.get(entry.pos);
+        if (existing) {
+            existing.glosses.push(...entry.glosses);
+        } else {
+            byPos.set(entry.pos, { pos: entry.pos, glosses: [...entry.glosses] });
+        }
+    }
+    return Array.from(byPos.values());
+});
+
+const hasSubstantiveContent = computed(() => {
+    const d = props.data;
+    if (d.etymology) return true;
+    if (d.pronunciation) return true;
+    if (mergedEntries.value.length > 1) return true;
+    if (mergedEntries.value.some((e) => e.glosses.length > 1)) return true;
+    if (mergedEntries.value.some((e) => e.glosses.some((s) => s.examples?.length))) return true;
+    return false;
+});
+
+function formatTags(tags: string[]): string {
+    return tags.join(', ');
+}
+</script>
+
+<template>
+    <section v-if="hasSubstantiveContent" class="dictionary">
+        <button class="dictionary-header" @click="expanded = !expanded">
+            <span class="dictionary-label">Dictionary</span>
+            <span class="dictionary-toggle" :class="{ open: expanded }">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                        d="M3 4.5L6 7.5L9 4.5"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                    />
+                </svg>
+            </span>
+        </button>
+
+        <div v-show="expanded" class="dictionary-body">
+            <!-- Pronunciation (IPA) -->
+            <div v-if="data.pronunciation" class="pronunciation">
+                <span class="ipa">{{ data.pronunciation }}</span>
+            </div>
+
+            <!-- Etymology -->
+            <div v-if="data.etymology" class="etymology">
+                <span class="etymology-label">Origin</span>
+                <p class="etymology-text">{{ data.etymology }}</p>
+            </div>
+
+            <!-- Entries grouped by part of speech -->
+            <div v-for="(entry, ei) in mergedEntries" :key="ei" class="pos-group">
+                <div class="pos-header">{{ entry.pos }}</div>
+
+                <ol class="senses">
+                    <li v-for="(sense, si) in entry.glosses" :key="si" class="sense">
+                        <span v-if="sense.tags?.length" class="sense-tags">
+                            {{ formatTags(sense.tags) }}
+                        </span>
+                        <span class="sense-gloss">{{ sense.gloss }}</span>
+
+                        <div v-if="sense.examples?.length" class="examples">
+                            <div
+                                v-for="(ex, exi) in sense.examples"
+                                :key="exi"
+                                class="example"
+                            >
+                                <span class="example-text">&ldquo;{{ ex.text }}&rdquo;</span>
+                                <span v-if="ex.translation" class="example-translation">
+                                    — {{ ex.translation }}
+                                </span>
+                            </div>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+
+            <!-- Forms (inflections) -->
+            <div v-if="data.forms?.length" class="forms">
+                <span class="forms-label">Forms</span>
+                <span class="forms-list">
+                    <span v-for="(f, fi) in data.forms" :key="fi" class="form-item">
+                        <em>{{ f.form }}</em>
+                        <span v-if="f.tags.length" class="form-tags">({{ f.tags.join(', ') }})</span>
+                        <span v-if="fi < data.forms!.length - 1" class="form-sep"> · </span>
+                    </span>
+                </span>
+            </div>
+
+            <!-- Attribution -->
+            <div class="attribution">
+                <a
+                    v-if="wiktionaryUrl"
+                    :href="wiktionaryUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="attribution-link"
+                >
+                    Wiktionary — CC BY-SA 4.0
+                </a>
+                <span v-else class="attribution-link">
+                    Source: Wiktionary — CC BY-SA 4.0
+                </span>
+            </div>
+        </div>
+    </section>
+</template>
+
+<style scoped>
+.dictionary {
+    border: 1px solid var(--color-rule);
+}
+
+.dictionary-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 14px 20px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-muted);
+    transition: color 150ms ease;
+}
+.dictionary-header:hover {
+    color: var(--color-ink);
+}
+.dictionary-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+}
+.dictionary-toggle {
+    transition: transform 200ms ease;
+}
+.dictionary-toggle.open {
+    transform: rotate(180deg);
+}
+
+.dictionary-body {
+    padding: 0 20px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* ── Pronunciation ── */
+.pronunciation {
+    font-family: var(--font-body);
+    font-size: 15px;
+    color: var(--color-muted);
+}
+.ipa {
+    font-style: italic;
+}
+
+/* ── Etymology ── */
+.etymology {
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--color-rule);
+}
+.etymology-label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 6px;
+}
+.etymology-text {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--color-ink);
+    opacity: 0.85;
+}
+
+/* ── Part of speech groups ── */
+.pos-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.pos-header {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 14px;
+    color: var(--color-muted);
+    font-variation-settings: 'opsz' 20;
+}
+
+/* ── Numbered senses ── */
+.senses {
+    margin: 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    counter-reset: sense;
+    list-style: none;
+}
+.sense {
+    counter-increment: sense;
+    position: relative;
+    font-family: var(--font-body);
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--color-ink);
+}
+.sense::before {
+    content: counter(sense) '.';
+    position: absolute;
+    left: -20px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+    top: 2px;
+}
+.sense-tags {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    font-style: italic;
+    margin-right: 4px;
+}
+.sense-gloss {
+    color: var(--color-ink);
+}
+
+/* ── Examples ── */
+.examples {
+    margin-top: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.example {
+    font-size: 13px;
+    line-height: 1.5;
+    padding-left: 12px;
+    border-left: 2px solid var(--color-rule);
+    color: var(--color-ink);
+    opacity: 0.75;
+}
+.example-text {
+    font-style: italic;
+}
+.example-translation {
+    color: var(--color-muted);
+    font-style: normal;
+}
+
+/* ── Forms ── */
+.forms {
+    padding-top: 12px;
+    border-top: 1px solid var(--color-rule);
+    font-family: var(--font-body);
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--color-ink);
+}
+.forms-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-right: 10px;
+}
+.form-tags {
+    color: var(--color-muted);
+    font-size: 11px;
+}
+.form-sep {
+    color: var(--color-rule);
+}
+
+/* ── Attribution ── */
+.attribution {
+    padding-top: 12px;
+    border-top: 1px solid var(--color-rule);
+}
+.attribution-link {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    text-decoration: none;
+    transition: color 120ms ease;
+}
+a.attribution-link:hover {
+    color: var(--color-accent);
+}
+</style>

--- a/components/word/WordTranslations.vue
+++ b/components/word/WordTranslations.vue
@@ -1,0 +1,145 @@
+<!--
+    WordTranslations — cross-language word links.
+    Shows translations of the current word in other languages.
+    Words with pages in our game link to their word detail pages.
+    Words without pages show as plain text (still useful context).
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { wordDetailPath } from '~/utils/wordUrls';
+
+export interface TranslationEntry {
+    code: string;
+    word: string;
+    hasPage: boolean;
+    name: string;
+}
+
+const props = withDefaults(
+    defineProps<{
+        translations: TranslationEntry[];
+        collapsed?: boolean;
+    }>(),
+    { collapsed: false }
+);
+
+const expanded = ref(!props.collapsed);
+
+const sorted = computed(() =>
+    [...props.translations]
+        .map((t) => ({
+            ...t,
+            href: t.hasPage ? wordDetailPath(t.code, t.word) : null,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+);
+</script>
+
+<template>
+    <section v-if="sorted.length" class="translations">
+            <button class="translations-header" @click="expanded = !expanded">
+                <span class="translations-label">This word in other languages</span>
+                <span class="translations-count">{{ sorted.length }}</span>
+                <span class="translations-toggle" :class="{ open: expanded }">
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                        <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </span>
+            </button>
+            <div v-show="expanded" class="translations-grid">
+                <component
+                    :is="t.href ? 'NuxtLink' : 'span'"
+                    v-for="t in sorted"
+                    :key="t.code"
+                    :to="t.href || undefined"
+                    class="translation-item"
+                    :class="{ linked: !!t.href }"
+                >
+                    <span class="translation-word">{{ t.word }}</span>
+                    <span class="translation-lang">{{ t.name }}</span>
+                </component>
+            </div>
+    </section>
+</template>
+
+<style scoped>
+.translations {
+    border: 1px solid var(--color-rule);
+}
+.translations-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 14px 20px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-muted);
+    transition: color 150ms ease;
+}
+.translations-header:hover {
+    color: var(--color-ink);
+}
+.translations-count {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--color-muted);
+    opacity: 0.6;
+}
+.translations-toggle {
+    margin-left: auto;
+    transition: transform 200ms ease;
+}
+.translations-toggle.open {
+    transform: rotate(180deg);
+}
+.translations-grid {
+    padding: 0 20px 16px;
+}
+.translations-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 12px;
+}
+.translations-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.translation-item {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid var(--color-rule);
+    text-decoration: none;
+}
+.translation-item.linked {
+    cursor: pointer;
+    transition: border-color 120ms ease;
+}
+.translation-item.linked:hover {
+    border-color: var(--color-ink);
+}
+.translation-word {
+    font-family: var(--font-display);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-ink);
+}
+.translation-item:not(.linked) .translation-word {
+    opacity: 0.6;
+}
+.translation-lang {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    text-transform: uppercase;
+}
+</style>

--- a/components/word/WordTranslations.vue
+++ b/components/word/WordTranslations.vue
@@ -38,28 +38,34 @@ const sorted = computed(() =>
 
 <template>
     <section v-if="sorted.length" class="translations">
-            <button class="translations-header" @click="expanded = !expanded">
-                <span class="translations-label">This word in other languages</span>
-                <span class="translations-count">{{ sorted.length }}</span>
-                <span class="translations-toggle" :class="{ open: expanded }">
-                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                        <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-                    </svg>
-                </span>
-            </button>
-            <div v-show="expanded" class="translations-grid">
-                <component
-                    :is="t.href ? 'NuxtLink' : 'span'"
-                    v-for="t in sorted"
-                    :key="t.code"
-                    :to="t.href || undefined"
-                    class="translation-item"
-                    :class="{ linked: !!t.href }"
-                >
-                    <span class="translation-word">{{ t.word }}</span>
-                    <span class="translation-lang">{{ t.name }}</span>
-                </component>
-            </div>
+        <button class="translations-header" @click="expanded = !expanded">
+            <span class="translations-label">This word in other languages</span>
+            <span class="translations-count">{{ sorted.length }}</span>
+            <span class="translations-toggle" :class="{ open: expanded }">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                        d="M3 4.5L6 7.5L9 4.5"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                    />
+                </svg>
+            </span>
+        </button>
+        <div v-show="expanded" class="translations-grid">
+            <component
+                :is="t.href ? 'NuxtLink' : 'span'"
+                v-for="t in sorted"
+                :key="t.code"
+                :to="t.href || undefined"
+                class="translation-item"
+                :class="{ linked: !!t.href }"
+            >
+                <span class="translation-word">{{ t.word }}</span>
+                <span class="translation-lang">{{ t.name }}</span>
+            </component>
+        </div>
     </section>
 </template>
 
@@ -70,6 +76,7 @@ const sorted = computed(() =>
 .translations-header {
     display: flex;
     align-items: center;
+    flex-wrap: nowrap;
     gap: 8px;
     width: 100%;
     padding: 14px 20px;
@@ -87,9 +94,11 @@ const sorted = computed(() =>
     font-size: 9px;
     color: var(--color-muted);
     opacity: 0.6;
+    flex-shrink: 0;
 }
 .translations-toggle {
     margin-left: auto;
+    flex-shrink: 0;
     transition: transform 200ms ease;
 }
 .translations-toggle.open {

--- a/composables/useAnalytics.ts
+++ b/composables/useAnalytics.ts
@@ -674,6 +674,15 @@ export function useAnalytics() {
     };
 
     /**
+     * Track a custom event with arbitrary params.
+     * Use for one-off feature-specific events (e.g. semantic mode interactions)
+     * that don't warrant a dedicated typed method.
+     */
+    const trackCustomEvent = (eventName: string, params?: Record<string, unknown>): void => {
+        track(eventName, params);
+    };
+
+    /**
      * Register game_mode as a PostHog super property on all future events.
      * Auto-attaches game_mode to every subsequent capture() call.
      * Call whenever gameConfig.mode changes.
@@ -772,6 +781,8 @@ export function useAnalytics() {
         registerLanguage,
         registerGameMode,
         trackGameRoundStart,
+        // Custom
+        trackCustomEvent,
         // Init
         initAbandonTracking,
         // PostHog user identification

--- a/composables/useBadgeNotification.ts
+++ b/composables/useBadgeNotification.ts
@@ -8,8 +8,8 @@
 export interface BadgeNotification {
     slug: string;
     name: string;
-    description: string;
-    icon: string;
+    description?: string;
+    icon?: string;
 }
 
 export function useBadgeNotification() {

--- a/composables/useDefinitions.ts
+++ b/composables/useDefinitions.ts
@@ -6,6 +6,7 @@
  * word appears across game modes (e.g., classic daily + archive + stats modal).
  */
 
+import { $fetch as ofetch } from 'ofetch';
 import type { WordDefinition } from '~/utils/types';
 
 /** Shape returned by the /api/[lang]/definition/[word] endpoint. */
@@ -39,9 +40,8 @@ export function useDefinitions() {
 
         const params = options?.cacheOnly ? '?cache_only=1' : '';
         try {
-            const data = (await $fetch(
-                `/api/${lang}/definition/${encodeURIComponent(word)}${params}`
-            )) as DefinitionApiResponse;
+            const url = `/api/${lang}/definition/${encodeURIComponent(word)}${params}`;
+            const data = (await ofetch(url)) as DefinitionApiResponse;
             const result: WordDefinition = {
                 word,
                 partOfSpeech: data.part_of_speech || undefined,
@@ -49,7 +49,7 @@ export function useDefinitions() {
                 definitionNative: data.definition_native || undefined,
                 definitionEn: data.definition_en || undefined,
                 confidence: data.confidence,
-                source: data.source || 'llm',
+                source: (data.source || 'llm') as WordDefinition['source'],
                 url: data.url || data.wiktionary_url || '',
             };
             _cache.set(key, result);

--- a/composables/useReportModal.ts
+++ b/composables/useReportModal.ts
@@ -1,0 +1,20 @@
+/**
+ * Global report modal state — shared across components.
+ */
+export function useReportModal() {
+    const showReportModal = useState<boolean>('show-report-modal', () => false);
+
+    function openReportModal() {
+        showReportModal.value = true;
+    }
+
+    function closeReportModal() {
+        showReportModal.value = false;
+    }
+
+    return {
+        showReportModal,
+        openReportModal,
+        closeReportModal,
+    };
+}

--- a/composables/useWordData.ts
+++ b/composables/useWordData.ts
@@ -52,6 +52,30 @@ export type WordBasic = {
     definition: WordBasicDefinition | null;
     /** Top 8 nearest neighbor words for SSR link juice + prefetch seed */
     nearest_words?: string[];
+    /** Pre-resolved image URL (server checks disk cache, avoids client HEAD probe) */
+    image_url?: string | null;
+    /** All game modes where this word appeared as a daily word */
+    appearances?: Array<{
+        mode: string;
+        dayIdx: number;
+        date: string;
+        board?: number;
+    }>;
+    /** Structured dictionary data from Wiktionary/kaikki */
+    dictionary?: {
+        senses: Array<{
+            pos: string;
+            glosses: Array<{
+                gloss: string;
+                examples?: Array<{ text: string; translation?: string }>;
+                tags?: string[];
+            }>;
+        }>;
+        etymology?: string | null;
+        pronunciation?: string | null;
+        forms?: Array<{ form: string; tags: string[] }> | null;
+        translations?: Array<{ code: string; word: string; hasPage: boolean; name: string }> | null;
+    } | null;
 };
 
 export type NeighborEntry = {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,6 +20,7 @@ export default defineNuxtConfig({
             autocapture: false,
             capture_pageview: 'history_change', // Auto-track SPA navigations
             capture_pageleave: false, // Disabled to reduce event volume (was ~61K/8 days)
+            // @ts-expect-error valid PostHog option not yet in type definitions
             enable_web_vitals: false, // Disabled to reduce event volume (was ~110K/8 days)
             session_recording: {
                 sampleRate: 0.03,

--- a/pages/[lang]/semantic.vue
+++ b/pages/[lang]/semantic.vue
@@ -108,7 +108,7 @@ const latestGuessWord = computed<string | null>(() => {
 const ui = computed(() => langStore.config?.ui);
 
 // --- Header meta ---
-const headerTitle = computed(() => ui.value?.semantic_title);
+const headerTitle = computed(() => ui.value?.semantic_title ?? 'Semantic Wordle');
 const headerSubtitle = computed(() => {
     const unlimitedLabel = ui.value?.semantic_unlimited;
     if (isUnlimited.value) return `${configVal.name_native || lang} · ${unlimitedLabel}`;
@@ -211,6 +211,7 @@ watch(
                     language: langStore.languageCode,
                     won: sem.won.value,
                     attempts: sem.guesses.value.length,
+                    streak_after: stats.stats.current_streak,
                     game_mode: 'semantic',
                     play_type: playType.value,
                     is_first_game: stats.stats.n_games === 0,
@@ -301,7 +302,7 @@ function onSliceToggle() {
     sem.toggleAxisSliceFromCompass();
     try {
         if (sem.mapMode.value === 'slice' && sem.sliceAxes.value) {
-            useAnalytics().trackCustomEvent?.('semantic_axis_slice_view', {
+            useAnalytics().trackCustomEvent('semantic_axis_slice_view', {
                 axis_x: sem.sliceAxes.value[0],
                 axis_y: sem.sliceAxes.value[1],
                 guess_number: sem.guesses.value.length,
@@ -316,7 +317,7 @@ function onSliceToggle() {
 async function onRequestLlmHint() {
     await sem.requestLlmHint();
     try {
-        useAnalytics().trackCustomEvent?.('semantic_llm_hint_used', {
+        useAnalytics().trackCustomEvent('semantic_llm_hint_used', {
             guess_number: sem.guesses.value.length,
         });
     } catch {
@@ -351,11 +352,7 @@ async function onShare() {
         emojiBoard: '',
         gameMode: 'semantic',
         onNotify: (message) => {
-            game.notification = {
-                message,
-                type: 'success',
-                ts: Date.now(),
-            } as typeof game.notification;
+            game.showNotification(message);
         },
     });
 }

--- a/pages/[lang]/speed.vue
+++ b/pages/[lang]/speed.vue
@@ -77,7 +77,7 @@ function startCountdown() {
         countdownNumber.value = 1;
     }, 2000);
     setTimeout(() => {
-        countdownNumber.value = langStore.config?.ui?.speed_go;
+        countdownNumber.value = langStore.config?.ui?.speed_go ?? 'GO!';
     }, 2700);
 }
 
@@ -188,7 +188,7 @@ onMounted(() => {
         :lang="lang"
         :language-name="config?.name_native || config?.name || lang"
         current-mode="speed"
-        :title="langStore.config?.ui?.speed_streak"
+        :title="langStore.config?.ui?.speed_streak ?? 'Speed Streak'"
         :subtitle="
             isDaily
                 ? `${config?.name_native || lang} · #${gameData?.mode_day_idx ?? gameData?.todays_idx}`

--- a/pages/[lang]/word/[slug].vue
+++ b/pages/[lang]/word/[slug].vue
@@ -343,7 +343,10 @@ useHead({
         { name: 'twitter:title', content: titleStr },
         { name: 'twitter:description', content: () => descriptionStr.value.slice(0, 200) },
         { name: 'twitter:image', content: ogImageStr },
-        { name: 'robots', content: () => (context.isCustom.value ? 'noindex,follow' : 'index,follow') },
+        {
+            name: 'robots',
+            content: () => (context.isCustom.value ? 'noindex,follow' : 'index,follow'),
+        },
     ],
     link: [{ rel: 'canonical', href: canonicalUrl }],
     script: [
@@ -356,9 +359,24 @@ useHead({
                         '@context': 'https://schema.org',
                         '@type': 'BreadcrumbList',
                         itemListElement: [
-                            { '@type': 'ListItem', position: 1, name: 'Wordle Global', item: 'https://wordle.global/' },
-                            { '@type': 'ListItem', position: 2, name: `Wordle ${langNameNative.value}`, item: `https://wordle.global/${lang}` },
-                            { '@type': 'ListItem', position: 3, name: word.value, item: canonicalUrl.value },
+                            {
+                                '@type': 'ListItem',
+                                position: 1,
+                                name: 'Wordle Global',
+                                item: 'https://wordle.global/',
+                            },
+                            {
+                                '@type': 'ListItem',
+                                position: 2,
+                                name: `Wordle ${langNameNative.value}`,
+                                item: `https://wordle.global/${lang}`,
+                            },
+                            {
+                                '@type': 'ListItem',
+                                position: 3,
+                                name: word.value,
+                                item: canonicalUrl.value,
+                            },
                         ],
                     };
                     const wordDateStr = primary.value?.basic?.word_date || '';
@@ -377,7 +395,9 @@ useHead({
                           }
                         : null;
                     return JSON.stringify(definedTerm ? [breadcrumb, definedTerm] : breadcrumb);
-                } catch { return '{}'; }
+                } catch {
+                    return '{}';
+                }
             }) as unknown as string,
         },
     ],
@@ -386,7 +406,9 @@ useHead({
 // ── Image ───────────────────────────────────────────────────────────────
 const imageUrl = computed(() => basicData.value?.image_url || null);
 const imageExpanded = ref(false);
-watch(word, () => { imageExpanded.value = false; });
+watch(word, () => {
+    imageExpanded.value = false;
+});
 
 // ── Wiktionary link ─────────────────────────────────────────────────────
 const wiktionaryUrl = computed(() => {
@@ -456,9 +478,15 @@ const dictionaryData = computed<DictionaryData | null>(() => {
 });
 
 const translations = computed(() => {
-    return (basicData.value?.dictionary?.translations as Array<{ code: string; word: string; hasPage: boolean; name: string }>) || [];
+    return (
+        (basicData.value?.dictionary?.translations as Array<{
+            code: string;
+            word: string;
+            hasPage: boolean;
+            name: string;
+        }>) || []
+    );
 });
-
 </script>
 
 <template>
@@ -502,7 +530,13 @@ const translations = computed(() => {
                                 aria-label="Expand image"
                             >
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                    <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                                    <path
+                                        d="M4 6L8 10L12 6"
+                                        stroke="currentColor"
+                                        stroke-width="1.5"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                    />
                                 </svg>
                             </button>
                         </div>
@@ -556,10 +590,7 @@ const translations = computed(() => {
                     </div>
 
                     <!-- Appeared in: game modes where this word was a daily word -->
-                    <section
-                        v-if="appearances.length"
-                        class="stats-section"
-                    >
+                    <section v-if="appearances.length" class="stats-section">
                         <div class="section-label">Appeared In</div>
                         <div class="appeared-in">
                             <div
@@ -728,7 +759,9 @@ const translations = computed(() => {
     border: none;
     cursor: pointer;
     opacity: 0.5;
-    transition: opacity 150ms ease, transform 200ms ease;
+    transition:
+        opacity 150ms ease,
+        transform 200ms ease;
     pointer-events: none;
 }
 .image-expand-hint.flipped {
@@ -859,7 +892,9 @@ const translations = computed(() => {
     padding: 4px 12px;
     border: 1px solid var(--color-rule);
     text-decoration: none;
-    transition: border-color 120ms ease, color 120ms ease;
+    transition:
+        border-color 120ms ease,
+        color 120ms ease;
 }
 .related-word-link:hover {
     color: var(--color-accent);

--- a/pages/[lang]/word/[slug].vue
+++ b/pages/[lang]/word/[slug].vue
@@ -5,7 +5,7 @@
  * Unified word detail + Explorer for any word. Slug is numeric (legacy,
  * redirected to word-name) or a canonical word name. The page is a single
  * editorial flow: headline → definition (if any) → image (if cached) →
- * Nearby in Meaning → daily stats (for daily words only) → share → Giscus.
+ * Nearby in Meaning → daily stats (for daily words only) → share → comments.
  *
  * The "Nearby in Meaning" section is the core interaction: it shows the
  * primary word plus its context (auto-selected neighbors or user-chosen
@@ -15,11 +15,16 @@
 import { computed, onMounted, ref, watch, onUnmounted } from 'vue';
 import { formatDateLong, getLocaleForIntl, RTL_LANGS } from '~/utils/locale';
 import { interpolate } from '~/utils/interpolate';
-import { wordDetailPath, wordDetailUrl, wordImageUrl } from '~/utils/wordUrls';
+import { wordDetailPath, wordDetailUrl } from '~/utils/wordUrls';
+import { GAME_MODES_UI } from '~/composables/useGameModes';
+import { Share2, Archive } from 'lucide-vue-next';
 import WordHeadline from '~/components/word/WordHeadline.vue';
-import WordImage from '~/components/word/WordImage.vue';
 import WordDefinition from '~/components/word/WordDefinition.vue';
+import WordDictionary from '~/components/word/WordDictionary.vue';
+import type { DictionaryData } from '~/components/word/WordDictionary.vue';
+import WordTranslations from '~/components/word/WordTranslations.vue';
 import NearbyInMeaning from '~/components/word/NearbyInMeaning.vue';
+import WordComments from '~/components/word/WordComments.vue';
 import type { WordBasic, WordData, WordExploreData } from '~/composables/useWordData';
 import type { WordDefinition as WordDefinitionType } from '~/utils/types';
 
@@ -263,6 +268,11 @@ const defText = computed(
     () => primary.value?.definition?.definitionNative || primary.value?.definition?.definition || ''
 );
 const posText = computed(() => primary.value?.definition?.partOfSpeech || '');
+const ogImageStr = computed(() => {
+    const imgUrl = basicData.value?.image_url;
+    if (imgUrl) return `https://wordle.global${imgUrl}`;
+    return `https://wordle.global/images/modes/classic/${lang}.png`;
+});
 const metaTemplates = computed(
     () =>
         ((primary.value?.basic?.meta as Record<string, unknown>)?.word_detail as Record<
@@ -315,94 +325,68 @@ const descriptionStr = computed(() => {
     return `Explore ${upperWord.value} — its meaning, semantic neighbors, and context in Wordle ${langNameNative.value}.`;
 });
 
-useSeoMeta({
+// Single useHead call — merging SEO meta, HTML attrs, link, and JSON-LD
+// into one registration avoids the @unhead/vue dispose bug where separate
+// useHead closures can have undefined `entry` on unmount.
+useHead({
     title: titleStr,
-    description: () => descriptionStr.value.slice(0, 200),
-    ogTitle: titleStr,
-    ogUrl: canonicalUrl,
-    ogType: 'article',
-    ogLocale: lang,
-    ogDescription: () => descriptionStr.value.slice(0, 200),
-    ogImage: () => (word.value ? wordImageUrl(lang, word.value, dayIdx.value) : undefined),
-    twitterCard: 'summary_large_image',
-    twitterTitle: titleStr,
-    twitterDescription: () => descriptionStr.value.slice(0, 200),
-    twitterImage: () => (word.value ? wordImageUrl(lang, word.value) : undefined),
-    robots: () => (context.isCustom.value ? 'noindex,follow' : 'index,follow'),
-});
-
-useHead({
     htmlAttrs: { lang, dir: RTL_LANGS.has(lang) ? 'rtl' : 'ltr' },
+    meta: [
+        { name: 'description', content: () => descriptionStr.value.slice(0, 200) },
+        { property: 'og:title', content: titleStr },
+        { property: 'og:url', content: canonicalUrl },
+        { property: 'og:type', content: 'article' },
+        { property: 'og:locale', content: lang },
+        { property: 'og:description', content: () => descriptionStr.value.slice(0, 200) },
+        { property: 'og:image', content: ogImageStr },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: titleStr },
+        { name: 'twitter:description', content: () => descriptionStr.value.slice(0, 200) },
+        { name: 'twitter:image', content: ogImageStr },
+        { name: 'robots', content: () => (context.isCustom.value ? 'noindex,follow' : 'index,follow') },
+    ],
     link: [{ rel: 'canonical', href: canonicalUrl }],
-});
-
-useHead({
     script: [
         {
             type: 'application/ld+json',
             innerHTML: computed(() => {
-                if (!word.value) return '{}';
-                const breadcrumb = {
-                    '@context': 'https://schema.org',
-                    '@type': 'BreadcrumbList',
-                    itemListElement: [
-                        {
-                            '@type': 'ListItem',
-                            position: 1,
-                            name: 'Wordle Global',
-                            item: 'https://wordle.global/',
-                        },
-                        {
-                            '@type': 'ListItem',
-                            position: 2,
-                            name: `Wordle ${langNameNative.value}`,
-                            item: `https://wordle.global/${lang}`,
-                        },
-                        {
-                            '@type': 'ListItem',
-                            position: 3,
-                            name: word.value,
-                            item: canonicalUrl.value,
-                        },
-                    ],
-                };
-                const wordDateStr = primary.value?.basic?.word_date || '';
-                const definedTerm = defText.value
-                    ? {
-                          '@context': 'https://schema.org',
-                          '@type': 'DefinedTerm',
-                          name: word.value,
-                          description: defText.value,
-                          inDefinedTermSet: `https://wordle.global/${lang}/archive`,
-                          url: canonicalUrl.value,
-                          ...(wordDateStr && { dateModified: wordDateStr }),
-                      }
-                    : null;
-                return JSON.stringify(definedTerm ? [breadcrumb, definedTerm] : breadcrumb);
+                try {
+                    if (!word.value) return '{}';
+                    const breadcrumb = {
+                        '@context': 'https://schema.org',
+                        '@type': 'BreadcrumbList',
+                        itemListElement: [
+                            { '@type': 'ListItem', position: 1, name: 'Wordle Global', item: 'https://wordle.global/' },
+                            { '@type': 'ListItem', position: 2, name: `Wordle ${langNameNative.value}`, item: `https://wordle.global/${lang}` },
+                            { '@type': 'ListItem', position: 3, name: word.value, item: canonicalUrl.value },
+                        ],
+                    };
+                    const wordDateStr = primary.value?.basic?.word_date || '';
+                    const dict = dictionaryData.value;
+                    const definedTerm = defText.value
+                        ? {
+                              '@context': 'https://schema.org',
+                              '@type': 'DefinedTerm',
+                              name: word.value,
+                              description: defText.value,
+                              inDefinedTermSet: `https://wordle.global/${lang}/archive`,
+                              url: canonicalUrl.value,
+                              ...(wordDateStr && { dateModified: wordDateStr }),
+                              ...(dict?.pronunciation && { pronunciation: dict.pronunciation }),
+                              ...(dict?.etymology && { termCode: posText.value || undefined }),
+                          }
+                        : null;
+                    return JSON.stringify(definedTerm ? [breadcrumb, definedTerm] : breadcrumb);
+                } catch { return '{}'; }
             }) as unknown as string,
         },
     ],
 });
 
-// ── Image availability ──────────────────────────────────────────────────
-// We only render the AI image section when there's a cached image. The
-// image endpoint returns 404 when nothing has been pre-generated — we
-// probe once on mount and hide the section entirely if so. This avoids
-// the ugly typographic-fallback block that duplicates the headline.
-const imageExists = ref(false);
-async function probeImage() {
-    if (!word.value) return;
-    try {
-        const resp = await fetch(wordImageUrl(lang, word.value, dayIdx.value), {
-            method: 'HEAD',
-        });
-        imageExists.value = resp.ok;
-    } catch {
-        imageExists.value = false;
-    }
-}
-watch(word, probeImage);
-onMounted(probeImage);
+// ── Image ───────────────────────────────────────────────────────────────
+const imageUrl = computed(() => basicData.value?.image_url || null);
+const imageExpanded = ref(false);
+watch(word, () => { imageExpanded.value = false; });
 
 // ── Wiktionary link ─────────────────────────────────────────────────────
 const wiktionaryUrl = computed(() => {
@@ -428,91 +412,10 @@ function shareWord() {
     }
 }
 
-// ── Giscus — stable-key mapping so URL changes don't orphan threads ─────
-const GISCUS_LANGS = new Set([
-    'ar',
-    'be',
-    'bg',
-    'ca',
-    'cs',
-    'da',
-    'de',
-    'en',
-    'eo',
-    'es',
-    'eu',
-    'fa',
-    'fr',
-    'he',
-    'hu',
-    'id',
-    'it',
-    'ja',
-    'ko',
-    'nl',
-    'pl',
-    'pt',
-    'ro',
-    'ru',
-    'th',
-    'tr',
-    'uk',
-    'uz',
-    'vi',
-]);
-const giscusLang = GISCUS_LANGS.has(lang.slice(0, 2)) ? lang.slice(0, 2) : 'en';
-const giscusContainer = ref<HTMLElement | null>(null);
+// ── Comments key — scopes the comment thread to this language + word ────
+const commentKey = computed(() => (word.value ? `${lang}-${word.value}` : ''));
 
-let giscusListener: ((e: MessageEvent) => void) | null = null;
-function removeGiscusListener() {
-    if (giscusListener) {
-        window.removeEventListener('message', giscusListener);
-        giscusListener = null;
-    }
-}
-function mountGiscus() {
-    if (!giscusContainer.value || !word.value) return;
-    removeGiscusListener();
-    giscusContainer.value.innerHTML = '';
-    const script = document.createElement('script');
-    script.src = 'https://giscus.app/client.js';
-    script.setAttribute('data-repo', 'Hugo0/wordle');
-    script.setAttribute('data-repo-id', 'R_kgDOG5D4ng');
-    script.setAttribute('data-category', 'Announcements');
-    script.setAttribute('data-category-id', 'DIC_kwDOG5D4ns4C3DFk');
-    script.setAttribute('data-mapping', 'specific');
-    script.setAttribute('data-term', `${lang}-word-${word.value}`);
-    script.setAttribute('data-strict', '1');
-    script.setAttribute('data-reactions-enabled', '1');
-    script.setAttribute('data-emit-metadata', '1');
-    script.setAttribute('data-input-position', 'bottom');
-    script.setAttribute(
-        'data-theme',
-        document.documentElement.classList.contains('dark') ? 'dark' : 'light'
-    );
-    script.setAttribute('data-lang', giscusLang);
-    script.setAttribute('data-loading', 'lazy');
-    script.crossOrigin = 'anonymous';
-    script.async = true;
-    giscusContainer.value.appendChild(script);
-
-    giscusListener = (event: MessageEvent) => {
-        if (event.origin !== 'https://giscus.app') return;
-        const iframe = document.querySelector('iframe.giscus-frame') as HTMLIFrameElement;
-        if (!iframe) return;
-        const isDark = document.documentElement.classList.contains('dark');
-        iframe.contentWindow?.postMessage(
-            { giscus: { setConfig: { theme: isDark ? 'dark' : 'light' } } },
-            'https://giscus.app'
-        );
-    };
-    window.addEventListener('message', giscusListener);
-}
-watch(word, (w) => {
-    if (w) mountGiscus();
-});
 onUnmounted(() => {
-    removeGiscusListener();
     prefetchTimers.forEach(clearTimeout);
     prefetchTimers = [];
 });
@@ -533,6 +436,29 @@ const subtitleText = computed(() => {
     if (!isDailyWord.value) return 'a portrait in meaning space';
     return '';
 });
+
+// Mode labels and icons from the canonical game mode UI config
+const modeLabels = Object.fromEntries(GAME_MODES_UI.map((m) => [m.id, m.label]));
+const modeIcons = Object.fromEntries(GAME_MODES_UI.map((m) => [m.id, m.icon]));
+
+const appearances = computed(() => basicData.value?.appearances ?? []);
+
+const dictionaryData = computed<DictionaryData | null>(() => {
+    const dict = basicData.value?.dictionary;
+    if (!dict?.senses || !word.value) return null;
+    return {
+        word: word.value,
+        entries: (dict.senses as DictionaryData['entries']) || [],
+        etymology: dict.etymology || undefined,
+        pronunciation: dict.pronunciation || undefined,
+        forms: (dict.forms as DictionaryData['forms']) || undefined,
+    };
+});
+
+const translations = computed(() => {
+    return (basicData.value?.dictionary?.translations as Array<{ code: string; word: string; hasPage: boolean; name: string }>) || [];
+});
+
 </script>
 
 <template>
@@ -550,66 +476,64 @@ const subtitleText = computed(() => {
                 <em>Loading…</em>
             </div>
 
-            <template v-else>
+            <div v-else class="word-content">
                 <div class="eyebrow text-center mb-5">{{ eyebrowText }}</div>
 
                 <div class="column">
                     <WordHeadline :word="word" :subtitle="subtitleText" size="lg" />
 
-                    <!-- Definition: show content or skeleton during transition -->
-                    <div
-                        v-if="transitioning && !primary.definition?.definition"
-                        class="definition-block skeleton-block"
-                    >
-                        <div class="skeleton-line w-3/4" />
-                        <div class="skeleton-line w-1/2" />
-                    </div>
-                    <div v-else-if="primary.definition?.definition" class="definition-block">
-                        <WordDefinition
-                            :word="word"
-                            :definition="primary.definition.definition"
-                            :part-of-speech="primary.definition.partOfSpeech"
-                            :ui="ui"
-                        />
-                        <a
-                            v-if="wiktionaryUrl"
-                            :href="wiktionaryUrl"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="wiktionary-link"
+                    <!-- Image (compact strip) + Definition — single editorial block -->
+                    <div class="word-card">
+                        <div
+                            v-if="imageUrl"
+                            class="image-wrap"
+                            @click="imageExpanded = !imageExpanded"
                         >
-                            Wiktionary →
-                        </a>
-                    </div>
-
-                    <!-- Image: only when a pre-generated image exists -->
-                    <div v-if="imageExists" class="image-wrap">
-                        <WordImage :word="word" :lang="lang" :day-idx="dayIdx" :size="400" />
-                    </div>
-
-                    <!-- SSR neighbor links: visible before client-side explore data
-                     loads. Provides internal link juice for crawlers and a
-                     visible "related words" section during hydration. Replaced
-                     by the interactive NearbyInMeaning graph once explore data
-                     arrives. -->
-                    <div
-                        v-if="!primary.explore && basicData?.nearest_words?.length"
-                        class="ssr-neighbors"
-                    >
-                        <div class="section-label">Related words</div>
-                        <div class="neighbor-links">
-                            <NuxtLink
-                                v-for="w in basicData.nearest_words"
-                                :key="w"
-                                :to="`/${lang}/word/${w}`"
-                                class="neighbor-link"
+                            <img
+                                :src="imageUrl"
+                                :alt="word"
+                                class="word-img"
+                                :class="{ expanded: imageExpanded }"
+                                loading="lazy"
+                            />
+                            <button
+                                class="image-expand-hint"
+                                :class="{ flipped: imageExpanded }"
+                                aria-label="Expand image"
                             >
-                                {{ w }}
-                            </NuxtLink>
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                    <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                                </svg>
+                            </button>
+                        </div>
+
+                        <div
+                            v-if="transitioning && !primary.definition?.definition"
+                            class="definition-block skeleton-block"
+                        >
+                            <div class="skeleton-line w-3/4" />
+                            <div class="skeleton-line w-1/2" />
+                        </div>
+                        <div v-else-if="primary.definition?.definition" class="definition-block">
+                            <WordDefinition
+                                :word="word"
+                                :definition="primary.definition.definition"
+                                :part-of-speech="primary.definition.partOfSpeech"
+                                :ui="ui"
+                            />
+                            <a
+                                v-if="wiktionaryUrl"
+                                :href="wiktionaryUrl"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="wiktionary-link"
+                            >
+                                Wiktionary →
+                            </a>
                         </div>
                     </div>
 
-                    <!-- Full interactive meaning map (English with embeddings) -->
+                    <!-- Meaning map — the hero visual, right after the word card -->
                     <NearbyInMeaning
                         v-if="primary.explore?.available"
                         :lang="lang"
@@ -623,18 +547,6 @@ const subtitleText = computed(() => {
                         @reset-to-auto="context.resetToAuto"
                     />
 
-                    <!-- Embeddings not available (non-English languages) -->
-                    <section
-                        v-else-if="primary.explore && !primary.explore.available"
-                        class="coming-soon-section"
-                    >
-                        <div class="section-label">Nearby in Meaning</div>
-                        <p class="coming-soon-text">
-                            Semantic maps are coming soon for {{ langNameNative }}.
-                        </p>
-                    </section>
-
-                    <!-- Skeleton for the graph during transitions -->
                     <div
                         v-if="transitioning && !primary.explore"
                         class="skeleton-block map-skeleton"
@@ -643,32 +555,95 @@ const subtitleText = computed(() => {
                         <div class="skeleton-map-box" />
                     </div>
 
-                    <!-- Appeared in: which daily modes featured this word -->
-                    <section v-if="isDailyWord" class="stats-section">
+                    <!-- Appeared in: game modes where this word was a daily word -->
+                    <section
+                        v-if="appearances.length"
+                        class="stats-section"
+                    >
                         <div class="section-label">Appeared In</div>
                         <div class="appeared-in">
-                            <div class="appeared-mode">
-                                <span class="appeared-mode-name">Classic Daily</span>
-                                <span class="appeared-mode-detail"
-                                    >#{{ dayIdx }} · {{ wordDate }}</span
-                                >
+                            <div
+                                v-for="app in appearances"
+                                :key="`${app.mode}-${app.dayIdx}`"
+                                class="appeared-mode"
+                            >
+                                <span class="appeared-mode-name">
+                                    <component
+                                        :is="modeIcons[app.mode]"
+                                        v-if="modeIcons[app.mode]"
+                                        :size="14"
+                                        class="mode-icon"
+                                    />
+                                    {{ modeLabels[app.mode] || app.mode }}
+                                    <span v-if="app.board != null" class="appeared-board">
+                                        Board {{ app.board + 1 }}
+                                    </span>
+                                </span>
+                                <span class="appeared-mode-detail">
+                                    #{{ app.dayIdx }} · {{ formatDateLong(app.date, lang) }}
+                                </span>
                             </div>
                         </div>
                     </section>
 
-                    <div class="share-wrap">
-                        <button class="text-btn accent" @click="shareWord">
-                            {{ shareBtnText }}
+                    <div class="actions-row">
+                        <button class="action-link" @click="shareWord">
+                            <Share2 :size="13" />
+                            <span>{{ shareBtnText }}</span>
                         </button>
-                        <NuxtLink :to="`/${lang}/archive`" class="text-btn"> ← archive </NuxtLink>
+                        <span class="action-sep">&middot;</span>
+                        <NuxtLink :to="`/${lang}/archive`" class="action-link">
+                            <Archive :size="13" />
+                            <span>Archive</span>
+                        </NuxtLink>
                     </div>
                 </div>
 
-                <section v-if="word" class="giscus-section">
-                    <div class="section-label">Discussion</div>
-                    <div ref="giscusContainer" class="giscus-mount" />
+                <!-- Comments -->
+                <section v-if="word && commentKey" class="comments-section-wrap">
+                    <WordComments
+                        target-type="word"
+                        :target-key="commentKey"
+                        :lang="lang"
+                        :appearances="appearances"
+                    />
                 </section>
-            </template>
+
+                <!-- Reference sections (collapsed, SEO-rich) -->
+                <div class="column reference-sections">
+                    <WordDictionary
+                        v-if="dictionaryData"
+                        :data="dictionaryData"
+                        :wiktionary-url="wiktionaryUrl"
+                        collapsed
+                    />
+
+                    <WordTranslations
+                        v-if="translations.length"
+                        :translations="translations"
+                        collapsed
+                    />
+
+                    <!-- Related words: always in DOM for SEO -->
+                    <div
+                        v-if="basicData?.nearest_words?.length"
+                        class="related-words"
+                        :class="{ 'sr-only-seo': primary?.explore?.available }"
+                    >
+                        <div class="related-words-label">Related Words</div>
+                        <div class="related-words-grid">
+                            <NuxtLink
+                                v-for="w in basicData.nearest_words"
+                                :key="w"
+                                :to="`/${lang}/word/${w}`"
+                                class="related-word-link"
+                            >
+                                {{ w }}
+                            </NuxtLink>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </AppShell>
 </template>
@@ -702,12 +677,15 @@ const subtitleText = computed(() => {
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: 36px;
+    gap: 24px;
 }
 
-.definition-block {
-    border-top: 1px solid var(--color-rule);
+.word-card {
+    border-top: 2px solid var(--color-ink);
     border-bottom: 1px solid var(--color-rule);
+    overflow: hidden;
+}
+.definition-block {
     padding: 20px 0;
     display: flex;
     flex-direction: column;
@@ -728,8 +706,43 @@ const subtitleText = computed(() => {
 }
 
 .image-wrap {
+    position: relative;
+    overflow: hidden;
+    border-bottom: 1px solid var(--color-rule);
+    cursor: pointer;
+}
+.image-wrap:hover .image-expand-hint {
+    opacity: 1;
+}
+.image-expand-hint {
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    width: 28px;
+    height: 28px;
     display: flex;
+    align-items: center;
     justify-content: center;
+    background: var(--color-ink);
+    color: var(--color-paper);
+    border: none;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 150ms ease, transform 200ms ease;
+    pointer-events: none;
+}
+.image-expand-hint.flipped {
+    transform: rotate(180deg);
+}
+.word-img {
+    width: 100%;
+    display: block;
+    object-fit: cover;
+    max-height: 120px;
+    transition: max-height 300ms ease;
+}
+.word-img.expanded {
+    max-height: 480px;
 }
 
 .stats-section {
@@ -754,54 +767,91 @@ const subtitleText = computed(() => {
     font-size: 14px;
     font-weight: 600;
     color: var(--color-ink);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.mode-icon {
+    color: var(--color-muted);
+    flex-shrink: 0;
 }
 .appeared-mode-detail {
     font-family: var(--font-mono);
     font-size: 11px;
     color: var(--color-muted);
 }
+.appeared-board {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-left: 6px;
+}
 
 .section-label {
     margin-bottom: 16px;
 }
 
-.share-wrap {
+.actions-row {
     display: flex;
+    align-items: center;
     justify-content: center;
-    gap: 16px;
+    gap: 12px;
 }
-.giscus-section {
-    max-width: 720px;
-    margin: 48px auto 0;
-    padding-top: 32px;
+.action-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    transition: color 120ms ease;
+}
+.action-link:hover {
+    color: var(--color-ink);
+}
+.action-sep {
+    color: var(--color-rule);
+    font-size: 14px;
+}
+.comments-section-wrap {
+    max-width: 640px;
+    margin: 32px auto 0;
+    padding-top: 24px;
     border-top: 1px solid var(--color-rule);
 }
-.giscus-mount {
-    min-height: 100px;
+.reference-sections {
+    margin-top: 32px;
+    padding-top: 24px;
+    border-top: 2px solid var(--color-ink);
 }
 
-/* ── SSR neighbor links (replaced by interactive graph on hydration) ── */
-.ssr-neighbors {
-    text-align: center;
+/* ── Related words (always in DOM for SEO) ── */
+.related-words {
+    border: 1px solid var(--color-rule);
+    padding: 16px 20px;
 }
-.coming-soon-section {
-    text-align: center;
-    padding: 32px 0;
-}
-.coming-soon-text {
-    font-family: var(--font-display);
-    font-size: 15px;
-    font-style: italic;
+.related-words-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
     color: var(--color-muted);
-    margin: 0;
+    margin-bottom: 12px;
 }
-.neighbor-links {
+.related-words-grid {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
     gap: 8px;
 }
-.neighbor-link {
+.related-word-link {
     font-family: var(--font-display);
     font-size: 14px;
     font-weight: 600;
@@ -809,15 +859,25 @@ const subtitleText = computed(() => {
     padding: 4px 12px;
     border: 1px solid var(--color-rule);
     text-decoration: none;
-    transition:
-        border-color 120ms ease,
-        color 120ms ease;
+    transition: border-color 120ms ease, color 120ms ease;
 }
-.neighbor-link:hover {
+.related-word-link:hover {
     color: var(--color-accent);
     border-color: var(--color-accent);
 }
-
+/* Visually hidden but in DOM for Google — used when the interactive
+   meaning map already shows the same neighbors as interactive chips */
+.sr-only-seo {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
 /* ── Skeleton loading states ── */
 .skeleton-block {
     display: flex;
@@ -852,7 +912,7 @@ const subtitleText = computed(() => {
         padding: 16px 12px 60px;
     }
     .column {
-        gap: 28px;
+        gap: 20px;
     }
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,7 @@ const pwaInstall = import.meta.client
               hasPrompt: boolean;
               isIOS: boolean;
           };
-      }>('pwaInstall', undefined)
+      }>('pwaInstall')
     : undefined;
 const showPwaInstall = ref(false);
 

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -6,6 +6,7 @@
  * Uses the editorial design system (Fraunces + Source Sans 3 + design tokens).
  * All data comes from localStorage game_results — no server data.
  */
+import type { Component } from 'vue';
 import { readJson } from '~/utils/storage';
 import { useAnimatedNumber } from '~/composables/useAnimatedNumber';
 import { BarChart2, Flame, Square, Zap, ChevronRight, Download } from 'lucide-vue-next';
@@ -23,7 +24,7 @@ const pwaInstall = import.meta.client
     ? inject<{
           install: () => void;
           status: () => { isStandalone: boolean; hasPrompt: boolean; isIOS: boolean };
-      }>('pwaInstall', undefined)
+      }>('pwaInstall')
     : undefined;
 const showInstallCta = computed(() => {
     if (!import.meta.client) return false;
@@ -67,7 +68,7 @@ interface PerLangStats {
 interface ModeStats {
     mode: GameMode;
     label: string;
-    icon: typeof Square;
+    icon: Component;
     games: number;
     wins: number;
     winPct: number;

--- a/plugins/sync.client.ts
+++ b/plugins/sync.client.ts
@@ -30,6 +30,7 @@ import {
     runStorageMigration,
     STORAGE_KEYS,
 } from '~/utils/storage';
+import { $fetch as ofetch } from 'ofetch';
 import type { GameResults, SpeedResults } from '~/utils/types';
 
 interface ServerResult {
@@ -216,7 +217,7 @@ async function pullResults(userId: string) {
             ? `/api/user/stats?since=${encodeURIComponent(lastSync)}`
             : '/api/user/stats';
 
-        const { results, settings: serverSettings } = (await $fetch(url)) as {
+        const { results, settings: serverSettings } = (await ofetch(url)) as {
             results: ServerResult[];
             settings: Record<string, boolean | string>;
         };

--- a/prisma/prisma.config.ts
+++ b/prisma/prisma.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { defineConfig } from 'prisma/config';
 
 export default defineConfig({
+    // @ts-expect-error earlyAccess is a valid runtime option not yet reflected in Prisma's type definitions
     earlyAccess: true,
     schema: path.join(__dirname, 'schema.prisma'),
     datasource: {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
     credentials   Credential[]
     badges        UserBadge[]
     subscription  Subscription?
+    comments      Comment[]
 
     @@map("users")
     @@schema("wordle")
@@ -153,6 +154,44 @@ model Subscription {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Comments & User Input
+// Unified table for all user-submitted content: word comments, leaderboard
+// discussion, bug reports, and feedback. The `type` field distinguishes them.
+// ═══════════════════════════════════════════════════════════════════════════
+
+model Comment {
+    id         String   @id @default(cuid())
+    userId     String?  @map("user_id")
+
+    /// What kind of entry: 'comment', 'report', 'feedback'
+    type       String
+
+    /// Scoping for comments: targetType + targetKey identify what this is about.
+    /// Reports/feedback leave these null (they're global, not attached to content).
+    /// Future comments: targetType='word' targetKey='en-hello',
+    /// or targetType='leaderboard' targetKey='en-classic-1756'.
+    targetType String?  @map("target_type")
+    targetKey  String?  @map("target_key")
+
+    body       String
+
+    /// Structured context — reports store {url, userAgent, screenSize, isPwa, lang, mode}
+    metadata   Json?
+
+    /// Soft-delete / moderation flag
+    hidden     Boolean  @default(false)
+
+    createdAt  DateTime @default(now()) @map("created_at")
+
+    user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+    @@index([type, targetType, targetKey, createdAt])
+    @@index([userId])
+    @@map("comments")
+    @@schema("wordle")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Caches (replacing disk-based JSON files)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -173,6 +212,12 @@ model Definition {
     url              String?
     isNegative       Boolean  @default(false) @map("is_negative")
     cachedAt         DateTime @default(now()) @map("cached_at")
+    // Rich dictionary data from kaikki.org (Wiktionary structured extract)
+    senses           Json?    // [{pos, glosses: [{gloss, examples?, tags?}]}]
+    etymology        String?
+    pronunciation    String?  // IPA
+    forms            Json?    // [{form, tags}]
+    translations     Json?    // {lang_code: word} — cross-language equivalents
 
     @@unique([lang, word])
     @@map("definitions")
@@ -224,6 +269,25 @@ model SemanticHint {
 
     @@unique([lang, word])
     @@map("semantic_hints")
+    @@schema("wordle")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Semantic Explorer — Pre-computed Neighbors
+// Top-N nearest words per target, ranked by cosine similarity.
+// Seeded by scripts/seed-semantic-db.ts. Used for game hints and word pages.
+// ═══════════════════════════════════════════════════════════════════════════
+
+model TargetNeighbor {
+    lang       String  @default("en")
+    targetWord String  @map("target_word")
+    word       String
+    rank       Int
+    cosine     Float   @db.Real
+
+    @@id([lang, targetWord, word])
+    @@index([lang, targetWord, rank], map: "target_neighbors_lookup_idx")
+    @@map("target_neighbors")
     @@schema("wordle")
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "arabic-reshaper>=3.0.0",
     "grapheme>=0.6.0",
     "openai>=2.21.0",
+    "pg8000>=1.31.5",
     "pillow>=12.1.1",
     "python-bidi==0.4.2",
 ]

--- a/scripts/import_dictionary.py
+++ b/scripts/import_dictionary.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Import structured dictionary data from kaikki.org into the definitions table.
+
+Downloads kaikki.org JSONL dumps, extracts rich structured data (all senses,
+etymology, IPA, forms, translations) for words in our word lists, and upserts
+into the Postgres `definitions` table's dictionary columns.
+
+Two editions:
+  1. Native (de, fr, es, ...) — definitions in the word's own language
+  2. English (en.wiktionary) — English glosses, also has translations
+
+Usage:
+    uv run scripts/import_dictionary.py download [--langs LANG1,LANG2,...] [--edition native|english|both]
+    uv run scripts/import_dictionary.py process [--langs LANG1,LANG2,...]
+    uv run scripts/import_dictionary.py upload [--langs LANG1,LANG2,...] [--dry-run]
+    uv run scripts/import_dictionary.py all [--langs LANG1,LANG2,...]
+
+Environment:
+    DATABASE_URL — Postgres connection string (reads from .env)
+"""
+
+import argparse
+import gzip
+import html
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+LANGUAGES_DIR = os.path.join(PROJECT_ROOT, "data", "languages")
+KAIKKI_DATA_DIR = os.path.join(SCRIPT_DIR, ".kaikki_data")
+PROCESSED_DIR = os.path.join(SCRIPT_DIR, ".kaikki_processed")
+
+# ---------------------------------------------------------------------------
+# Language mappings (from build_definitions.py)
+# ---------------------------------------------------------------------------
+
+LANG_CODE_TO_KAIKKI_NAME = {
+    "ar": "Arabic", "az": "Azerbaijani", "bg": "Bulgarian", "br": "Breton",
+    "ca": "Catalan", "ckb": "Central Kurdish", "cs": "Czech", "da": "Danish",
+    "de": "German", "el": "Greek", "en": "English", "eo": "Esperanto",
+    "es": "Spanish", "et": "Estonian", "eu": "Basque", "fa": "Persian",
+    "fi": "Finnish", "fo": "Faroese", "fr": "French", "fur": "Friulian",
+    "fy": "West Frisian", "ga": "Irish", "gd": "Scottish Gaelic", "gl": "Galician",
+    "he": "Hebrew", "hr": "Serbo-Croatian", "hu": "Hungarian", "hy": "Armenian",
+    "hyw": "Western Armenian", "ia": "Interlingua", "ie": "Interlingue",
+    "is": "Icelandic", "it": "Italian", "ka": "Georgian", "ko": "Korean",
+    "la": "Latin", "lb": "Luxembourgish", "lt": "Lithuanian", "ltg": "Latgalian",
+    "lv": "Latvian", "mi": "Māori", "mk": "Macedonian", "mn": "Mongolian",
+    "nb": "Norwegian Bokmål", "nds": "German Low German", "ne": "Nepali",
+    "nl": "Dutch", "nn": "Norwegian Nynorsk", "oc": "Occitan",
+    "pau": "Palauan", "pl": "Polish", "pt": "Portuguese", "qya": "Quenya",
+    "ro": "Romanian", "ru": "Russian", "rw": "Kinyarwanda", "sk": "Slovak",
+    "sl": "Slovene", "sr": "Serbo-Croatian", "sv": "Swedish", "tk": "Turkmen",
+    "tlh": "Klingon", "tr": "Turkish", "uk": "Ukrainian", "vi": "Vietnamese",
+}
+
+NATIVE_EDITION_MAP = {
+    "cs": "cs", "de": "de", "el": "el", "es": "es", "fr": "fr",
+    "it": "it", "ko": "ko", "nl": "nl", "pl": "pl", "pt": "pt",
+    "ru": "ru", "tr": "tr", "vi": "vi",
+}
+
+# All our supported language codes (for filtering translations)
+ALL_OUR_LANGS = set()
+
+# Offensive sense tags — skip these
+OFFENSIVE_TAGS = {"derogatory", "offensive", "slur", "vulgar", "pejorative"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_all_lang_codes():
+    codes = sorted(
+        d for d in os.listdir(LANGUAGES_DIR)
+        if os.path.isdir(os.path.join(LANGUAGES_DIR, d))
+    )
+    ALL_OUR_LANGS.update(codes)
+    return codes
+
+
+def load_word_set(lang_code):
+    """Load all words for a language from words.json. Returns lowercase set."""
+    words_file = os.path.join(LANGUAGES_DIR, lang_code, "words.json")
+    if not os.path.isfile(words_file):
+        return set()
+    try:
+        with open(words_file, encoding="utf-8") as f:
+            data = json.load(f)
+        return {w["word"].lower() for w in data.get("words", []) if w.get("word")}
+    except (json.JSONDecodeError, KeyError):
+        return set()
+
+
+def clean_gloss(text):
+    """Clean wiki markup from a gloss string."""
+    text = html.unescape(text)
+    text = re.sub(r"\{\{[^}]*\}\}", "", text)
+    text = re.sub(r"\[\[([^\]|]*\|)?([^\]]*)\]\]", r"\2", text)
+    text = re.sub(r"[\[\]{}]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > 300:
+        cut = text[:300].rfind(".")
+        text = text[: cut + 1] if cut > 100 else text[:300] + "…"
+    return text
+
+
+def is_unhelpful(gloss):
+    """Skip bare grammatical forms and form-of references."""
+    if re.match(r"^(alternative |obsolete |archaic )?(form|spelling) of\b", gloss, re.I):
+        return True
+    if re.match(r"^See \w+\.?$", gloss, re.I):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Download (reuses logic from build_definitions.py)
+# ---------------------------------------------------------------------------
+
+def kaikki_url(lang_name):
+    dir_part = urllib.parse.quote(lang_name, safe="")
+    filename_base = lang_name.replace(" ", "").replace("-", "")
+    filename = f"kaikki.org-dictionary-{filename_base}.jsonl.gz"
+    return f"https://kaikki.org/dictionary/{dir_part}/{urllib.parse.quote(filename, safe='.-')}"
+
+
+def native_edition_url(wikt_code):
+    return f"https://kaikki.org/dictionary/downloads/{wikt_code}/{wikt_code}-extract.jsonl.gz"
+
+
+def download_file(url, dest):
+    print(f"  Downloading: {url}")
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "WordleGlobal/1.0"})
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            total = resp.headers.get("Content-Length")
+            total = int(total) if total else None
+            downloaded = 0
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "wb") as out:
+                while True:
+                    chunk = resp.read(256 * 1024)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        pct = downloaded * 100 // total
+                        print(f"\r  {downloaded / 1e6:.1f}/{total / 1e6:.1f} MB ({pct}%)", end="", flush=True)
+            print(f"\r  Done: {downloaded / 1e6:.1f} MB" + " " * 30)
+            return True
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print("  Not found (404)")
+            return False
+        raise
+    except Exception as e:
+        print(f"  Error: {e}")
+        return False
+
+
+def cmd_download(lang_codes, edition="both"):
+    os.makedirs(KAIKKI_DATA_DIR, exist_ok=True)
+
+    if edition in ("native", "both"):
+        needed = {NATIVE_EDITION_MAP[lc] for lc in lang_codes if lc in NATIVE_EDITION_MAP}
+        if needed:
+            print(f"\n=== Native editions ({len(needed)}) ===\n")
+            for code in sorted(needed):
+                dest = os.path.join(KAIKKI_DATA_DIR, f"native_{code}-extract.jsonl.gz")
+                if os.path.isfile(dest):
+                    print(f"[{code}] native: exists ({os.path.getsize(dest) / 1e6:.1f} MB)")
+                    continue
+                print(f"[{code}] native:")
+                download_file(native_edition_url(code), dest)
+
+    if edition in ("english", "both"):
+        seen = {}
+        plan = []
+        for lc in lang_codes:
+            name = LANG_CODE_TO_KAIKKI_NAME.get(lc)
+            if not name or name in seen:
+                continue
+            seen[name] = lc
+            plan.append((lc, name))
+
+        print(f"\n=== English edition ({len(plan)} languages) ===\n")
+        for lc, name in plan:
+            safe = name.replace(" ", "_").replace("-", "_")
+            dest = os.path.join(KAIKKI_DATA_DIR, f"{lc}_{safe}.jsonl.gz")
+            if os.path.isfile(dest):
+                print(f"[{lc}] {name}: exists ({os.path.getsize(dest) / 1e6:.1f} MB)")
+                continue
+            print(f"[{lc}] {name}:")
+            download_file(kaikki_url(name), dest)
+
+
+# ---------------------------------------------------------------------------
+# Process — extract rich structured data
+# ---------------------------------------------------------------------------
+
+def extract_from_jsonl(gz_path, target_words, lang_code_filter=None):
+    """Extract rich dictionary data from a kaikki JSONL file.
+
+    Returns: {word: {
+        "senses": [{pos, glosses: [{gloss, tags?, examples?, synonyms?}]}],
+        "etymology": str | None,
+        "pronunciation": str | None,
+        "forms": [{form, tags}] | None,
+        "translations": [{code, word}] | None,
+    }}
+    """
+    # Accumulate entries by word — each word may have multiple POS entries
+    raw = {}  # word -> [{pos, glosses, etymology, ipa, forms, translations}]
+
+    with gzip.open(gz_path, "rt", encoding="utf-8") as f:
+      try:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            word = entry.get("word", "").lower()
+            if word not in target_words:
+                continue
+
+            if lang_code_filter and entry.get("lang_code") != lang_code_filter:
+                continue
+
+            pos = entry.get("pos", "unknown")
+
+            # Etymology
+            etymology = entry.get("etymology_text") or ""
+            if not etymology:
+                texts = entry.get("etymology_texts", [])
+                if texts:
+                    etymology = texts[0] if isinstance(texts, list) else ""
+            etymology = html.unescape(etymology).strip() if etymology else None
+            # Skip tree-format etymologies
+            if etymology and (etymology.startswith("Etymology tree") or etymology.count("\n") > 3):
+                etymology = None
+
+            # IPA
+            sounds = entry.get("sounds", [])
+            ipas = [s["ipa"] for s in sounds if isinstance(s, dict) and "ipa" in s]
+            ipa = ", ".join(ipas[:3]) if ipas else None
+
+            # Forms — filter to useful ones (actual word forms, not metadata)
+            forms_raw = entry.get("forms", [])
+            forms = []
+            for fm in forms_raw:
+                if not isinstance(fm, dict):
+                    continue
+                form_text = fm.get("form", "")
+                tags = fm.get("tags", [])
+                # Skip metadata entries
+                if any(t in tags for t in ["table-tags", "inflection-template", "class"]):
+                    continue
+                if not form_text or form_text.startswith("no-") or form_text.startswith("fi-"):
+                    continue
+                # Keep only common useful tags
+                clean_tags = [t for t in tags if t not in ("declension", "conjugation", "mutation")]
+                if clean_tags and form_text:
+                    forms.append({"form": html.unescape(form_text), "tags": clean_tags})
+
+            # Translations (only from English edition entries)
+            trans_raw = entry.get("translations", [])
+            translations = []
+            for t in trans_raw:
+                if not isinstance(t, dict):
+                    continue
+                tcode = t.get("lang_code", "")
+                tword = t.get("word", "")
+                if tcode and tword and tcode in ALL_OUR_LANGS:
+                    translations.append({"code": tcode, "word": html.unescape(tword)})
+
+            # Senses/glosses
+            glosses = []
+            for sense in entry.get("senses", []):
+                sense_glosses = sense.get("glosses", [])
+                if not sense_glosses:
+                    continue
+                # Use last gloss (most specific) or first if only one
+                gloss_text = sense_glosses[-1] if len(sense_glosses) > 1 else sense_glosses[0]
+                gloss_text = clean_gloss(gloss_text)
+                if not gloss_text or len(gloss_text) < 3:
+                    continue
+                if is_unhelpful(gloss_text):
+                    continue
+
+                # Skip offensive senses
+                tags = set(sense.get("tags", []))
+                if tags & OFFENSIVE_TAGS:
+                    continue
+
+                g = {"gloss": gloss_text}
+                clean_tags = [t for t in sense.get("tags", []) if t not in OFFENSIVE_TAGS]
+                if clean_tags:
+                    g["tags"] = clean_tags[:5]
+
+                # Examples
+                examples = []
+                for ex in sense.get("examples", []):
+                    if isinstance(ex, dict):
+                        text = html.unescape(ex.get("text", "")).strip()
+                        if text and len(text) > 5:
+                            e = {"text": text[:200]}
+                            tr = ex.get("english", "") or ex.get("translation", "")
+                            if tr:
+                                e["translation"] = html.unescape(tr)[:200]
+                            examples.append(e)
+                if examples:
+                    g["examples"] = examples[:3]
+
+                # Synonyms
+                syn_list = []
+                for syn in sense.get("synonyms", []):
+                    if isinstance(syn, dict) and syn.get("word"):
+                        syn_list.append(syn["word"])
+                if syn_list:
+                    g["synonyms"] = syn_list[:5]
+
+                glosses.append(g)
+
+            if not glosses:
+                continue
+
+            if word not in raw:
+                raw[word] = []
+            raw[word].append({
+                "pos": pos,
+                "glosses": glosses,
+                "etymology": etymology,
+                "ipa": ipa,
+                "forms": forms,
+                "translations": translations,
+            })
+      except EOFError:
+        print(f"    Warning: truncated gzip file, processing {len(raw)} words found so far")
+
+    # Merge into final format
+    results = {}
+    for word, entries in raw.items():
+        # Merge same-POS entries
+        by_pos = {}
+        best_etymology = None
+        best_ipa = None
+        all_forms = []
+        all_translations = {}
+
+        for e in entries:
+            pos = e["pos"]
+            if pos not in by_pos:
+                by_pos[pos] = []
+            by_pos[pos].extend(e["glosses"])
+
+            if not best_etymology and e["etymology"]:
+                best_etymology = e["etymology"]
+            if not best_ipa and e["ipa"]:
+                best_ipa = e["ipa"]
+            all_forms.extend(e["forms"])
+            for t in e["translations"]:
+                key = t["code"]
+                if key not in all_translations:
+                    all_translations[key] = t["word"]
+
+        senses = [{"pos": p, "glosses": g} for p, g in by_pos.items()]
+
+        # Deduplicate forms
+        seen_forms = set()
+        unique_forms = []
+        for fm in all_forms:
+            key = (fm["form"], tuple(fm["tags"]))
+            if key not in seen_forms:
+                seen_forms.add(key)
+                unique_forms.append(fm)
+
+        results[word] = {
+            "senses": senses,
+            "etymology": best_etymology,
+            "pronunciation": best_ipa,
+            "forms": unique_forms[:20] if unique_forms else None,
+            "translations": all_translations if all_translations else None,
+        }
+
+    return results
+
+
+def find_english_gz(lang_code):
+    name = LANG_CODE_TO_KAIKKI_NAME.get(lang_code)
+    if not name:
+        return None
+    safe = name.replace(" ", "_").replace("-", "_")
+    path = os.path.join(KAIKKI_DATA_DIR, f"{lang_code}_{safe}.jsonl.gz")
+    if os.path.isfile(path):
+        return path
+    # Check shared names (hr/sr -> Serbo-Croatian)
+    for lc, n in LANG_CODE_TO_KAIKKI_NAME.items():
+        if n == name:
+            safe2 = n.replace(" ", "_").replace("-", "_")
+            p2 = os.path.join(KAIKKI_DATA_DIR, f"{lc}_{safe2}.jsonl.gz")
+            if os.path.isfile(p2):
+                return p2
+    return None
+
+
+def cmd_process(lang_codes):
+    os.makedirs(PROCESSED_DIR, exist_ok=True)
+    print(f"\nProcessing {len(lang_codes)} languages...\n")
+
+    for lc in sorted(lang_codes):
+        words = load_word_set(lc)
+        if not words:
+            print(f"  [{lc}] No words — skip")
+            continue
+
+        result = {}
+
+        # Native edition first (definitions in the word's own language)
+        wikt_code = NATIVE_EDITION_MAP.get(lc)
+        if wikt_code:
+            gz = os.path.join(KAIKKI_DATA_DIR, f"native_{wikt_code}-extract.jsonl.gz")
+            if os.path.isfile(gz):
+                native = extract_from_jsonl(gz, words, lang_code_filter=lc)
+                result.update(native)
+
+        # English edition as supplement (fills gaps + adds translations)
+        en_gz = find_english_gz(lc)
+        if en_gz:
+            english = extract_from_jsonl(en_gz, words)
+            for w, data in english.items():
+                if w not in result:
+                    # No native data — use English glosses
+                    result[w] = data
+                else:
+                    # Native data exists — only take translations from English
+                    if data.get("translations") and not result[w].get("translations"):
+                        result[w]["translations"] = data["translations"]
+
+        # For English, native = english
+        if lc == "en" and not result:
+            en_gz = find_english_gz("en")
+            if en_gz:
+                result = extract_from_jsonl(en_gz, words)
+
+        n = len(result)
+        coverage = n * 100 / len(words) if words else 0
+        print(f"  [{lc}] {n}/{len(words)} ({coverage:.0f}%)")
+
+        # Write processed data
+        out_path = os.path.join(PROCESSED_DIR, f"{lc}.json")
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False)
+
+    print(f"\nProcessed data in: {PROCESSED_DIR}")
+
+
+# ---------------------------------------------------------------------------
+# Upload — write to Postgres
+# ---------------------------------------------------------------------------
+
+def cmd_upload(lang_codes, dry_run=False):
+    import pg8000
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        env_path = os.path.join(PROJECT_ROOT, ".env")
+        if os.path.isfile(env_path):
+            with open(env_path) as f:
+                for line in f:
+                    if line.startswith("DATABASE_URL="):
+                        db_url = line.split("=", 1)[1].strip().strip('"')
+                        break
+    if not db_url:
+        print("ERROR: DATABASE_URL not set", file=sys.stderr)
+        sys.exit(1)
+
+    from urllib.parse import urlparse, unquote
+    parsed = urlparse(db_url)
+    conn = pg8000.connect(
+        host=parsed.hostname, port=parsed.port or 5432,
+        user=unquote(parsed.username or ""), password=unquote(parsed.password or ""),
+        database=parsed.path.lstrip("/"), ssl_context=True,
+    )
+    cursor = conn.cursor()
+    total = 0
+    BATCH = 500
+
+    for lc in sorted(lang_codes):
+        path = os.path.join(PROCESSED_DIR, f"{lc}.json")
+        if not os.path.isfile(path):
+            continue
+        data = json.load(open(path, encoding="utf-8"))
+        if not data:
+            continue
+
+        items = list(data.items())
+        count = 0
+
+        for i in range(0, len(items), BATCH):
+            batch = items[i:i + BATCH]
+            if dry_run:
+                count += len(batch)
+                continue
+
+            # Build multi-row INSERT ... ON CONFLICT
+            values = []
+            params = []
+            for idx, (word, entry) in enumerate(batch):
+                sj = json.dumps(entry["senses"], ensure_ascii=False)
+                fj = json.dumps(entry["forms"], ensure_ascii=False) if entry.get("forms") else None
+                tj = json.dumps(entry["translations"], ensure_ascii=False) if entry.get("translations") else None
+                base = idx * 7
+                values.append(f"(${base+1}, ${base+2}, ${base+3}::jsonb, ${base+4}, ${base+5}, ${base+6}::jsonb, ${base+7}::jsonb)")
+                params.extend([lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj])
+
+            sql = f"""INSERT INTO wordle.definitions (lang, word, senses, etymology, pronunciation, forms, translations)
+                VALUES {', '.join(values)}
+                ON CONFLICT (lang, word) DO UPDATE SET
+                    senses = EXCLUDED.senses,
+                    etymology = EXCLUDED.etymology,
+                    pronunciation = EXCLUDED.pronunciation,
+                    forms = COALESCE(EXCLUDED.forms, wordle.definitions.forms),
+                    translations = COALESCE(EXCLUDED.translations, wordle.definitions.translations)"""
+
+            try:
+                cursor.execute(sql, params)
+                count += len(batch)
+            except Exception as e:
+                # pg8000 may not support $N placeholders, fall back to %s
+                conn.rollback()
+                # Retry with %s placeholders
+                values2 = []
+                params2 = []
+                for word, entry in batch:
+                    sj = json.dumps(entry["senses"], ensure_ascii=False)
+                    fj = json.dumps(entry["forms"], ensure_ascii=False) if entry.get("forms") else None
+                    tj = json.dumps(entry["translations"], ensure_ascii=False) if entry.get("translations") else None
+                    values2.append("(%s, %s, %s::jsonb, %s, %s, %s::jsonb, %s::jsonb)")
+                    params2.extend([lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj])
+                sql2 = f"""INSERT INTO wordle.definitions (lang, word, senses, etymology, pronunciation, forms, translations)
+                    VALUES {', '.join(values2)}
+                    ON CONFLICT (lang, word) DO UPDATE SET
+                        senses = EXCLUDED.senses, etymology = EXCLUDED.etymology,
+                        pronunciation = EXCLUDED.pronunciation,
+                        forms = EXCLUDED.forms, translations = EXCLUDED.translations"""
+                cursor.execute(sql2, params2)
+                count += len(batch)
+
+            conn.commit()
+
+        total += count
+        print(f"  [{lc}] {count} upserted", flush=True)
+
+    conn.close()
+    print(f"\nTotal: {total} rows upserted")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Import kaikki.org dictionary data")
+    parser.add_argument("command", choices=["download", "process", "upload", "all", "stats"])
+    parser.add_argument("--langs", help="Comma-separated language codes (default: all)")
+    parser.add_argument("--edition", choices=["native", "english", "both"], default="both")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    all_codes = get_all_lang_codes()
+    lang_codes = args.langs.split(",") if args.langs else all_codes
+
+    if args.command == "download":
+        cmd_download(lang_codes, edition=args.edition)
+    elif args.command == "process":
+        cmd_process(lang_codes)
+    elif args.command == "upload":
+        cmd_upload(lang_codes, dry_run=args.dry_run)
+    elif args.command == "all":
+        cmd_download(lang_codes, edition=args.edition)
+        cmd_process(lang_codes)
+        cmd_upload(lang_codes, dry_run=args.dry_run)
+    elif args.command == "stats":
+        for lc in sorted(lang_codes):
+            p = os.path.join(PROCESSED_DIR, f"{lc}.json")
+            if os.path.isfile(p):
+                d = json.load(open(p))
+                words = load_word_set(lc)
+                print(f"  [{lc}] {len(d)}/{len(words)} ({len(d)*100//max(len(words),1)}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/import_dictionary.py
+++ b/scripts/import_dictionary.py
@@ -40,29 +40,87 @@ PROCESSED_DIR = os.path.join(SCRIPT_DIR, ".kaikki_processed")
 # ---------------------------------------------------------------------------
 
 LANG_CODE_TO_KAIKKI_NAME = {
-    "ar": "Arabic", "az": "Azerbaijani", "bg": "Bulgarian", "br": "Breton",
-    "ca": "Catalan", "ckb": "Central Kurdish", "cs": "Czech", "da": "Danish",
-    "de": "German", "el": "Greek", "en": "English", "eo": "Esperanto",
-    "es": "Spanish", "et": "Estonian", "eu": "Basque", "fa": "Persian",
-    "fi": "Finnish", "fo": "Faroese", "fr": "French", "fur": "Friulian",
-    "fy": "West Frisian", "ga": "Irish", "gd": "Scottish Gaelic", "gl": "Galician",
-    "he": "Hebrew", "hr": "Serbo-Croatian", "hu": "Hungarian", "hy": "Armenian",
-    "hyw": "Western Armenian", "ia": "Interlingua", "ie": "Interlingue",
-    "is": "Icelandic", "it": "Italian", "ka": "Georgian", "ko": "Korean",
-    "la": "Latin", "lb": "Luxembourgish", "lt": "Lithuanian", "ltg": "Latgalian",
-    "lv": "Latvian", "mi": "Māori", "mk": "Macedonian", "mn": "Mongolian",
-    "nb": "Norwegian Bokmål", "nds": "German Low German", "ne": "Nepali",
-    "nl": "Dutch", "nn": "Norwegian Nynorsk", "oc": "Occitan",
-    "pau": "Palauan", "pl": "Polish", "pt": "Portuguese", "qya": "Quenya",
-    "ro": "Romanian", "ru": "Russian", "rw": "Kinyarwanda", "sk": "Slovak",
-    "sl": "Slovene", "sr": "Serbo-Croatian", "sv": "Swedish", "tk": "Turkmen",
-    "tlh": "Klingon", "tr": "Turkish", "uk": "Ukrainian", "vi": "Vietnamese",
+    "ar": "Arabic",
+    "az": "Azerbaijani",
+    "bg": "Bulgarian",
+    "br": "Breton",
+    "ca": "Catalan",
+    "ckb": "Central Kurdish",
+    "cs": "Czech",
+    "da": "Danish",
+    "de": "German",
+    "el": "Greek",
+    "en": "English",
+    "eo": "Esperanto",
+    "es": "Spanish",
+    "et": "Estonian",
+    "eu": "Basque",
+    "fa": "Persian",
+    "fi": "Finnish",
+    "fo": "Faroese",
+    "fr": "French",
+    "fur": "Friulian",
+    "fy": "West Frisian",
+    "ga": "Irish",
+    "gd": "Scottish Gaelic",
+    "gl": "Galician",
+    "he": "Hebrew",
+    "hr": "Serbo-Croatian",
+    "hu": "Hungarian",
+    "hy": "Armenian",
+    "hyw": "Western Armenian",
+    "ia": "Interlingua",
+    "ie": "Interlingue",
+    "is": "Icelandic",
+    "it": "Italian",
+    "ka": "Georgian",
+    "ko": "Korean",
+    "la": "Latin",
+    "lb": "Luxembourgish",
+    "lt": "Lithuanian",
+    "ltg": "Latgalian",
+    "lv": "Latvian",
+    "mi": "Māori",
+    "mk": "Macedonian",
+    "mn": "Mongolian",
+    "nb": "Norwegian Bokmål",
+    "nds": "German Low German",
+    "ne": "Nepali",
+    "nl": "Dutch",
+    "nn": "Norwegian Nynorsk",
+    "oc": "Occitan",
+    "pau": "Palauan",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "qya": "Quenya",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "rw": "Kinyarwanda",
+    "sk": "Slovak",
+    "sl": "Slovene",
+    "sr": "Serbo-Croatian",
+    "sv": "Swedish",
+    "tk": "Turkmen",
+    "tlh": "Klingon",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
 }
 
 NATIVE_EDITION_MAP = {
-    "cs": "cs", "de": "de", "el": "el", "es": "es", "fr": "fr",
-    "it": "it", "ko": "ko", "nl": "nl", "pl": "pl", "pt": "pt",
-    "ru": "ru", "tr": "tr", "vi": "vi",
+    "cs": "cs",
+    "de": "de",
+    "el": "el",
+    "es": "es",
+    "fr": "fr",
+    "it": "it",
+    "ko": "ko",
+    "nl": "nl",
+    "pl": "pl",
+    "pt": "pt",
+    "ru": "ru",
+    "tr": "tr",
+    "vi": "vi",
 }
 
 # All our supported language codes (for filtering translations)
@@ -75,10 +133,10 @@ OFFENSIVE_TAGS = {"derogatory", "offensive", "slur", "vulgar", "pejorative"}
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def get_all_lang_codes():
     codes = sorted(
-        d for d in os.listdir(LANGUAGES_DIR)
-        if os.path.isdir(os.path.join(LANGUAGES_DIR, d))
+        d for d in os.listdir(LANGUAGES_DIR) if os.path.isdir(os.path.join(LANGUAGES_DIR, d))
     )
     ALL_OUR_LANGS.update(codes)
     return codes
@@ -93,7 +151,7 @@ def load_word_set(lang_code):
         with open(words_file, encoding="utf-8") as f:
             data = json.load(f)
         return {w["word"].lower() for w in data.get("words", []) if w.get("word")}
-    except (json.JSONDecodeError, KeyError):
+    except json.JSONDecodeError, KeyError:
         return set()
 
 
@@ -114,14 +172,13 @@ def is_unhelpful(gloss):
     """Skip bare grammatical forms and form-of references."""
     if re.match(r"^(alternative |obsolete |archaic )?(form|spelling) of\b", gloss, re.I):
         return True
-    if re.match(r"^See \w+\.?$", gloss, re.I):
-        return True
-    return False
+    return bool(re.match(r"^See \w+\.?$", gloss, re.I))
 
 
 # ---------------------------------------------------------------------------
 # Download (reuses logic from build_definitions.py)
 # ---------------------------------------------------------------------------
+
 
 def kaikki_url(lang_name):
     dir_part = urllib.parse.quote(lang_name, safe="")
@@ -152,7 +209,11 @@ def download_file(url, dest):
                     downloaded += len(chunk)
                     if total:
                         pct = downloaded * 100 // total
-                        print(f"\r  {downloaded / 1e6:.1f}/{total / 1e6:.1f} MB ({pct}%)", end="", flush=True)
+                        print(
+                            f"\r  {downloaded / 1e6:.1f}/{total / 1e6:.1f} MB ({pct}%)",
+                            end="",
+                            flush=True,
+                        )
             print(f"\r  Done: {downloaded / 1e6:.1f} MB" + " " * 30)
             return True
     except urllib.error.HTTPError as e:
@@ -205,6 +266,7 @@ def cmd_download(lang_codes, edition="both"):
 # Process — extract rich structured data
 # ---------------------------------------------------------------------------
 
+
 def extract_from_jsonl(gz_path, target_words, lang_code_filter=None):
     """Extract rich dictionary data from a kaikki JSONL file.
 
@@ -220,133 +282,139 @@ def extract_from_jsonl(gz_path, target_words, lang_code_filter=None):
     raw = {}  # word -> [{pos, glosses, etymology, ipa, forms, translations}]
 
     with gzip.open(gz_path, "rt", encoding="utf-8") as f:
-      try:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            word = entry.get("word", "").lower()
-            if word not in target_words:
-                continue
-
-            if lang_code_filter and entry.get("lang_code") != lang_code_filter:
-                continue
-
-            pos = entry.get("pos", "unknown")
-
-            # Etymology
-            etymology = entry.get("etymology_text") or ""
-            if not etymology:
-                texts = entry.get("etymology_texts", [])
-                if texts:
-                    etymology = texts[0] if isinstance(texts, list) else ""
-            etymology = html.unescape(etymology).strip() if etymology else None
-            # Skip tree-format etymologies
-            if etymology and (etymology.startswith("Etymology tree") or etymology.count("\n") > 3):
-                etymology = None
-
-            # IPA
-            sounds = entry.get("sounds", [])
-            ipas = [s["ipa"] for s in sounds if isinstance(s, dict) and "ipa" in s]
-            ipa = ", ".join(ipas[:3]) if ipas else None
-
-            # Forms — filter to useful ones (actual word forms, not metadata)
-            forms_raw = entry.get("forms", [])
-            forms = []
-            for fm in forms_raw:
-                if not isinstance(fm, dict):
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
                     continue
-                form_text = fm.get("form", "")
-                tags = fm.get("tags", [])
-                # Skip metadata entries
-                if any(t in tags for t in ["table-tags", "inflection-template", "class"]):
-                    continue
-                if not form_text or form_text.startswith("no-") or form_text.startswith("fi-"):
-                    continue
-                # Keep only common useful tags
-                clean_tags = [t for t in tags if t not in ("declension", "conjugation", "mutation")]
-                if clean_tags and form_text:
-                    forms.append({"form": html.unescape(form_text), "tags": clean_tags})
-
-            # Translations (only from English edition entries)
-            trans_raw = entry.get("translations", [])
-            translations = []
-            for t in trans_raw:
-                if not isinstance(t, dict):
-                    continue
-                tcode = t.get("lang_code", "")
-                tword = t.get("word", "")
-                if tcode and tword and tcode in ALL_OUR_LANGS:
-                    translations.append({"code": tcode, "word": html.unescape(tword)})
-
-            # Senses/glosses
-            glosses = []
-            for sense in entry.get("senses", []):
-                sense_glosses = sense.get("glosses", [])
-                if not sense_glosses:
-                    continue
-                # Use last gloss (most specific) or first if only one
-                gloss_text = sense_glosses[-1] if len(sense_glosses) > 1 else sense_glosses[0]
-                gloss_text = clean_gloss(gloss_text)
-                if not gloss_text or len(gloss_text) < 3:
-                    continue
-                if is_unhelpful(gloss_text):
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
                     continue
 
-                # Skip offensive senses
-                tags = set(sense.get("tags", []))
-                if tags & OFFENSIVE_TAGS:
+                word = entry.get("word", "").lower()
+                if word not in target_words:
                     continue
 
-                g = {"gloss": gloss_text}
-                clean_tags = [t for t in sense.get("tags", []) if t not in OFFENSIVE_TAGS]
-                if clean_tags:
-                    g["tags"] = clean_tags[:5]
+                if lang_code_filter and entry.get("lang_code") != lang_code_filter:
+                    continue
 
-                # Examples
-                examples = []
-                for ex in sense.get("examples", []):
-                    if isinstance(ex, dict):
-                        text = html.unescape(ex.get("text", "")).strip()
-                        if text and len(text) > 5:
-                            e = {"text": text[:200]}
-                            tr = ex.get("english", "") or ex.get("translation", "")
-                            if tr:
-                                e["translation"] = html.unescape(tr)[:200]
-                            examples.append(e)
-                if examples:
-                    g["examples"] = examples[:3]
+                pos = entry.get("pos", "unknown")
 
-                # Synonyms
-                syn_list = []
-                for syn in sense.get("synonyms", []):
-                    if isinstance(syn, dict) and syn.get("word"):
-                        syn_list.append(syn["word"])
-                if syn_list:
-                    g["synonyms"] = syn_list[:5]
+                # Etymology
+                etymology = entry.get("etymology_text") or ""
+                if not etymology:
+                    texts = entry.get("etymology_texts", [])
+                    if texts:
+                        etymology = texts[0] if isinstance(texts, list) else ""
+                etymology = html.unescape(etymology).strip() if etymology else None
+                # Skip tree-format etymologies
+                if etymology and (
+                    etymology.startswith("Etymology tree") or etymology.count("\n") > 3
+                ):
+                    etymology = None
 
-                glosses.append(g)
+                # IPA
+                sounds = entry.get("sounds", [])
+                ipas = [s["ipa"] for s in sounds if isinstance(s, dict) and "ipa" in s]
+                ipa = ", ".join(ipas[:3]) if ipas else None
 
-            if not glosses:
-                continue
+                # Forms — filter to useful ones (actual word forms, not metadata)
+                forms_raw = entry.get("forms", [])
+                forms = []
+                for fm in forms_raw:
+                    if not isinstance(fm, dict):
+                        continue
+                    form_text = fm.get("form", "")
+                    tags = fm.get("tags", [])
+                    # Skip metadata entries
+                    if any(t in tags for t in ["table-tags", "inflection-template", "class"]):
+                        continue
+                    if not form_text or form_text.startswith("no-") or form_text.startswith("fi-"):
+                        continue
+                    # Keep only common useful tags
+                    clean_tags = [
+                        t for t in tags if t not in ("declension", "conjugation", "mutation")
+                    ]
+                    if clean_tags and form_text:
+                        forms.append({"form": html.unescape(form_text), "tags": clean_tags})
 
-            if word not in raw:
-                raw[word] = []
-            raw[word].append({
-                "pos": pos,
-                "glosses": glosses,
-                "etymology": etymology,
-                "ipa": ipa,
-                "forms": forms,
-                "translations": translations,
-            })
-      except EOFError:
-        print(f"    Warning: truncated gzip file, processing {len(raw)} words found so far")
+                # Translations (only from English edition entries)
+                trans_raw = entry.get("translations", [])
+                translations = []
+                for t in trans_raw:
+                    if not isinstance(t, dict):
+                        continue
+                    tcode = t.get("lang_code", "")
+                    tword = t.get("word", "")
+                    if tcode and tword and tcode in ALL_OUR_LANGS:
+                        translations.append({"code": tcode, "word": html.unescape(tword)})
+
+                # Senses/glosses
+                glosses = []
+                for sense in entry.get("senses", []):
+                    sense_glosses = sense.get("glosses", [])
+                    if not sense_glosses:
+                        continue
+                    # Use last gloss (most specific) or first if only one
+                    gloss_text = sense_glosses[-1] if len(sense_glosses) > 1 else sense_glosses[0]
+                    gloss_text = clean_gloss(gloss_text)
+                    if not gloss_text or len(gloss_text) < 3:
+                        continue
+                    if is_unhelpful(gloss_text):
+                        continue
+
+                    # Skip offensive senses
+                    tags = set(sense.get("tags", []))
+                    if tags & OFFENSIVE_TAGS:
+                        continue
+
+                    g = {"gloss": gloss_text}
+                    clean_tags = [t for t in sense.get("tags", []) if t not in OFFENSIVE_TAGS]
+                    if clean_tags:
+                        g["tags"] = clean_tags[:5]
+
+                    # Examples
+                    examples = []
+                    for ex in sense.get("examples", []):
+                        if isinstance(ex, dict):
+                            text = html.unescape(ex.get("text", "")).strip()
+                            if text and len(text) > 5:
+                                e = {"text": text[:200]}
+                                tr = ex.get("english", "") or ex.get("translation", "")
+                                if tr:
+                                    e["translation"] = html.unescape(tr)[:200]
+                                examples.append(e)
+                    if examples:
+                        g["examples"] = examples[:3]
+
+                    # Synonyms
+                    syn_list = []
+                    for syn in sense.get("synonyms", []):
+                        if isinstance(syn, dict) and syn.get("word"):
+                            syn_list.append(syn["word"])
+                    if syn_list:
+                        g["synonyms"] = syn_list[:5]
+
+                    glosses.append(g)
+
+                if not glosses:
+                    continue
+
+                if word not in raw:
+                    raw[word] = []
+                raw[word].append(
+                    {
+                        "pos": pos,
+                        "glosses": glosses,
+                        "etymology": etymology,
+                        "ipa": ipa,
+                        "forms": forms,
+                        "translations": translations,
+                    }
+                )
+        except EOFError:
+            print(f"    Warning: truncated gzip file, processing {len(raw)} words found so far")
 
     # Merge into final format
     results = {}
@@ -469,6 +537,7 @@ def cmd_process(lang_codes):
 # Upload — write to Postgres
 # ---------------------------------------------------------------------------
 
+
 def cmd_upload(lang_codes, dry_run=False):
     import pg8000
 
@@ -485,12 +554,16 @@ def cmd_upload(lang_codes, dry_run=False):
         print("ERROR: DATABASE_URL not set", file=sys.stderr)
         sys.exit(1)
 
-    from urllib.parse import urlparse, unquote
+    from urllib.parse import unquote, urlparse
+
     parsed = urlparse(db_url)
     conn = pg8000.connect(
-        host=parsed.hostname, port=parsed.port or 5432,
-        user=unquote(parsed.username or ""), password=unquote(parsed.password or ""),
-        database=parsed.path.lstrip("/"), ssl_context=True,
+        host=parsed.hostname,
+        port=parsed.port or 5432,
+        user=unquote(parsed.username or ""),
+        password=unquote(parsed.password or ""),
+        database=parsed.path.lstrip("/"),
+        ssl_context=True,
     )
     cursor = conn.cursor()
     total = 0
@@ -500,7 +573,8 @@ def cmd_upload(lang_codes, dry_run=False):
         path = os.path.join(PROCESSED_DIR, f"{lc}.json")
         if not os.path.isfile(path):
             continue
-        data = json.load(open(path, encoding="utf-8"))
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
         if not data:
             continue
 
@@ -508,7 +582,7 @@ def cmd_upload(lang_codes, dry_run=False):
         count = 0
 
         for i in range(0, len(items), BATCH):
-            batch = items[i:i + BATCH]
+            batch = items[i : i + BATCH]
             if dry_run:
                 count += len(batch)
                 continue
@@ -519,13 +593,21 @@ def cmd_upload(lang_codes, dry_run=False):
             for idx, (word, entry) in enumerate(batch):
                 sj = json.dumps(entry["senses"], ensure_ascii=False)
                 fj = json.dumps(entry["forms"], ensure_ascii=False) if entry.get("forms") else None
-                tj = json.dumps(entry["translations"], ensure_ascii=False) if entry.get("translations") else None
+                tj = (
+                    json.dumps(entry["translations"], ensure_ascii=False)
+                    if entry.get("translations")
+                    else None
+                )
                 base = idx * 7
-                values.append(f"(${base+1}, ${base+2}, ${base+3}::jsonb, ${base+4}, ${base+5}, ${base+6}::jsonb, ${base+7}::jsonb)")
-                params.extend([lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj])
+                values.append(
+                    f"(${base + 1}, ${base + 2}, ${base + 3}::jsonb, ${base + 4}, ${base + 5}, ${base + 6}::jsonb, ${base + 7}::jsonb)"
+                )
+                params.extend(
+                    [lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj]
+                )
 
             sql = f"""INSERT INTO wordle.definitions (lang, word, senses, etymology, pronunciation, forms, translations)
-                VALUES {', '.join(values)}
+                VALUES {", ".join(values)}
                 ON CONFLICT (lang, word) DO UPDATE SET
                     senses = EXCLUDED.senses,
                     etymology = EXCLUDED.etymology,
@@ -536,7 +618,7 @@ def cmd_upload(lang_codes, dry_run=False):
             try:
                 cursor.execute(sql, params)
                 count += len(batch)
-            except Exception as e:
+            except Exception:
                 # pg8000 may not support $N placeholders, fall back to %s
                 conn.rollback()
                 # Retry with %s placeholders
@@ -544,12 +626,22 @@ def cmd_upload(lang_codes, dry_run=False):
                 params2 = []
                 for word, entry in batch:
                     sj = json.dumps(entry["senses"], ensure_ascii=False)
-                    fj = json.dumps(entry["forms"], ensure_ascii=False) if entry.get("forms") else None
-                    tj = json.dumps(entry["translations"], ensure_ascii=False) if entry.get("translations") else None
+                    fj = (
+                        json.dumps(entry["forms"], ensure_ascii=False)
+                        if entry.get("forms")
+                        else None
+                    )
+                    tj = (
+                        json.dumps(entry["translations"], ensure_ascii=False)
+                        if entry.get("translations")
+                        else None
+                    )
                     values2.append("(%s, %s, %s::jsonb, %s, %s, %s::jsonb, %s::jsonb)")
-                    params2.extend([lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj])
+                    params2.extend(
+                        [lc, word, sj, entry.get("etymology"), entry.get("pronunciation"), fj, tj]
+                    )
                 sql2 = f"""INSERT INTO wordle.definitions (lang, word, senses, etymology, pronunciation, forms, translations)
-                    VALUES {', '.join(values2)}
+                    VALUES {", ".join(values2)}
                     ON CONFLICT (lang, word) DO UPDATE SET
                         senses = EXCLUDED.senses, etymology = EXCLUDED.etymology,
                         pronunciation = EXCLUDED.pronunciation,
@@ -569,6 +661,7 @@ def cmd_upload(lang_codes, dry_run=False):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(description="Import kaikki.org dictionary data")
@@ -595,9 +688,10 @@ def main():
         for lc in sorted(lang_codes):
             p = os.path.join(PROCESSED_DIR, f"{lc}.json")
             if os.path.isfile(p):
-                d = json.load(open(p))
+                with open(p) as f:
+                    d = json.load(f)
                 words = load_word_set(lc)
-                print(f"  [{lc}] {len(d)}/{len(words)} ({len(d)*100//max(len(words),1)}%)")
+                print(f"  [{lc}] {len(d)}/{len(words)} ({len(d) * 100 // max(len(words), 1)}%)")
 
 
 if __name__ == "__main__":

--- a/server/api/[lang]/semantic/guess.post.ts
+++ b/server/api/[lang]/semantic/guess.post.ts
@@ -64,7 +64,7 @@ export default defineEventHandler(async (event) => {
 
     const allProjectionsNormalized = semanticDb.projectAxes(guessVec);
 
-    let compassResult = { hints: [] as any[], status: 'close' as const, totalExplained: 0 };
+    let compassResult: { hints: any[]; status: 'ok' | 'close'; totalExplained: number } = { hints: [], status: 'close', totalExplained: 0 };
     const cachedAxes = semanticDb.getCachedAxes();
     if (cachedAxes) {
         try {

--- a/server/api/[lang]/semantic/guess.post.ts
+++ b/server/api/[lang]/semantic/guess.post.ts
@@ -64,7 +64,11 @@ export default defineEventHandler(async (event) => {
 
     const allProjectionsNormalized = semanticDb.projectAxes(guessVec);
 
-    let compassResult: { hints: any[]; status: 'ok' | 'close'; totalExplained: number } = { hints: [], status: 'close', totalExplained: 0 };
+    let compassResult: { hints: any[]; status: 'ok' | 'close'; totalExplained: number } = {
+        hints: [],
+        status: 'close',
+        totalExplained: 0,
+    };
     const cachedAxes = semanticDb.getCachedAxes();
     if (cachedAxes) {
         try {

--- a/server/api/[lang]/word-image/[word].get.ts
+++ b/server/api/[lang]/word-image/[word].get.ts
@@ -62,19 +62,19 @@ export default defineEventHandler(async (event) => {
         throw createError({ statusCode: 400, message: 'Invalid word' });
     }
 
-    const openaiKey = process.env.OPENAI_API_KEY;
-    if (!openaiKey) {
-        throw createError({ statusCode: 404, message: 'Not available' });
-    }
-
     const cacheDir = join(WORD_IMAGES_DIR, lang);
     const cachePath = join(cacheDir, `${word.toLowerCase()}.webp`);
 
-    // Serve cached image
+    // Serve cached image (works even without API key)
     if (existsSync(cachePath)) {
         setResponseHeader(event, 'Content-Type', 'image/webp');
         setResponseHeader(event, 'Cache-Control', 'public, max-age=31536000');
         return readFileSync(cachePath);
+    }
+
+    const openaiKey = process.env.OPENAI_API_KEY;
+    if (!openaiKey) {
+        throw createError({ statusCode: 404, message: 'Not available' });
     }
 
     // Rate limit DALL-E generation (cached images bypass this)
@@ -132,7 +132,7 @@ export default defineEventHandler(async (event) => {
             n: 1,
         });
 
-        const imageUrl = response.data[0]?.url;
+        const imageUrl = response.data?.[0]?.url;
         if (!imageUrl?.startsWith('https://')) {
             throw new Error('Image generation returned no URL');
         }

--- a/server/api/[lang]/word/[slug].get.ts
+++ b/server/api/[lang]/word/[slug].get.ts
@@ -5,18 +5,28 @@
  * Resolution + validation are delegated to `resolveWordSlug`, which also
  * fixes up Unicode word slugs for non-English languages.
  */
-import { loadAllData, requireLang, langResponseFields } from '../../../utils/data-loader';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import {
+    loadAllData,
+    requireLang,
+    langResponseFields,
+    WORD_IMAGES_DIR,
+} from '../../../utils/data-loader';
+import { wordImagePath } from '~/utils/wordUrls';
 import {
     getTodaysIdx,
     getWiktLang,
     idxToDate,
     resolveWordSlug,
+    findWordAppearances,
 } from '../../../utils/word-selection';
 import { loadWordStats } from '../../../utils/word-stats';
 import { fetchDefinition } from '../../../utils/definitions';
 import { checkWiktionaryExists } from '../../../utils/wiktionary';
 import * as semanticDb from '~/server/utils/_semantic-db';
 import { getValidWords } from '~/server/plugins/semantic-warmup';
+import { prisma } from '~/server/utils/prisma';
 import type { WordStats } from '~/utils/types';
 
 // Module-level Set cache so we don't rebuild on every request. wordLists
@@ -107,10 +117,30 @@ export default defineEventHandler(async (event) => {
     const cacheOnly = clientCacheOnly || !isGameWord;
 
     let wiktionaryExists = false;
+    let dictionary: {
+        senses: unknown;
+        etymology?: string | null;
+        pronunciation?: string | null;
+        forms?: unknown;
+        translations?: unknown;
+    } | null = null;
+
     if (word) {
-        const [defResult, wiktResult] = await Promise.all([
+        const [defResult, wiktResult, dictRow] = await Promise.all([
             fetchDefinition(word, lang, { cacheOnly }).catch(() => null),
             checkWiktionaryExists(word, lang).catch(() => null),
+            prisma.definition
+                .findUnique({
+                    where: { lang_word: { lang, word: word.toLowerCase() } },
+                    select: {
+                        senses: true,
+                        etymology: true,
+                        pronunciation: true,
+                        forms: true,
+                        translations: true,
+                    },
+                })
+                .catch(() => null),
         ]);
         if (defResult) {
             definition = {
@@ -120,6 +150,40 @@ export default defineEventHandler(async (event) => {
             };
         }
         wiktionaryExists = wiktResult === true;
+        if (dictRow?.senses || dictRow?.translations) {
+            // Tag translations: linkable (word exists in our lists) vs display-only
+            let translationsList: Array<{
+                code: string;
+                word: string;
+                hasPage: boolean;
+                name: string;
+            }> | null = null;
+            if (dictRow?.translations && typeof dictRow.translations === 'object') {
+                const raw = dictRow.translations as Record<string, string>;
+                translationsList = [];
+                for (const [code, tw] of Object.entries(raw)) {
+                    if (data.languageCodes.includes(code) && code !== lang) {
+                        const wordSet = getWordSet(code, data);
+                        const langConfig = data.configs[code];
+                        translationsList.push({
+                            code,
+                            word: tw,
+                            hasPage: wordSet.has(tw.toLowerCase()),
+                            name: langConfig?.name || code,
+                        });
+                    }
+                }
+                translationsList.sort((a, b) => a.name.localeCompare(b.name));
+                if (translationsList.length === 0) translationsList = null;
+            }
+            dictionary = {
+                senses: dictRow?.senses || null,
+                etymology: dictRow?.etymology,
+                pronunciation: dictRow?.pronunciation,
+                forms: dictRow?.forms,
+                translations: translationsList,
+            };
+        }
     }
 
     // Nearest words for SSR internal link juice via pgvector HNSW — ~10ms.
@@ -133,6 +197,16 @@ export default defineEventHandler(async (event) => {
             // DB unavailable — skip
         }
     }
+
+    let imageUrl: string | null = null;
+    if (word) {
+        const imgPath = join(WORD_IMAGES_DIR, lang, `${word.toLowerCase()}.webp`);
+        if (existsSync(imgPath)) {
+            imageUrl = wordImagePath(lang, word, dayIdx);
+        }
+    }
+
+    const appearances = word ? findWordAppearances(lang, word) : [];
 
     return {
         ...langResponseFields(lang, config),
@@ -149,5 +223,8 @@ export default defineEventHandler(async (event) => {
         wikt_lang: getWiktLang(lang),
         wiktionary_exists: wiktionaryExists,
         nearest_words: nearestWords,
+        image_url: imageUrl,
+        appearances,
+        dictionary,
     };
 });

--- a/server/api/[lang]/words.get.ts
+++ b/server/api/[lang]/words.get.ts
@@ -12,11 +12,10 @@
  * Multi-board modes return `words: string[]` per entry (N words per day).
  * Semantic mode is English-only and returns target words from the semantic pool.
  */
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
-import { WORD_DEFS_DIR, requireLang, langResponseFields } from '../../utils/data-loader';
+import { requireLang, langResponseFields } from '../../utils/data-loader';
 import { getTodaysIdx, getWordForDay, getWordsForDay, idxToDate } from '../../utils/word-selection';
 import { loadWordStats } from '../../utils/word-stats';
+import { fetchDefinition } from '../../utils/definitions';
 import { getTodaysIdx as getTodaysIdxLib, toModeDayIdx, fromModeDayIdx } from '../../lib/day-index';
 import { GAME_MODE_CONFIG } from '~/utils/game-modes';
 import type { GameMode } from '~/utils/game-modes';
@@ -47,20 +46,19 @@ const ARCHIVE_MODES = new Set([
 ]);
 
 /**
- * Read a cached definition from disk without triggering LLM generation.
+ * Read a definition from the DB without triggering LLM generation.
+ * Uses the same fetchDefinition() as word pages — one code path for all surfaces.
  */
-function readCachedDefinition(
+async function readDefinition(
     word: string,
     langCode: string
-): { definition: string; part_of_speech?: string } | null {
-    const cachePath = join(WORD_DEFS_DIR, langCode, `${word.toLowerCase()}.json`);
-    if (!existsSync(cachePath)) return null;
+): Promise<{ definition: string; part_of_speech?: string } | null> {
     try {
-        const loaded = JSON.parse(readFileSync(cachePath, 'utf-8'));
-        if (loaded.not_found || !loaded.definition) return null;
+        const result = await fetchDefinition(word, langCode, { cacheOnly: true });
+        if (!result) return null;
         return {
-            definition: loaded.definition_native || loaded.definition,
-            part_of_speech: loaded.part_of_speech || undefined,
+            definition: result.definition_native || result.definition,
+            part_of_speech: result.part_of_speech || undefined,
         };
     } catch {
         return null;
@@ -185,11 +183,11 @@ export default defineEventHandler(async (event) => {
 
             // Definitions only make sense for single-word modes
             if (word && boardCount === 1) {
-                defResult = readCachedDefinition(word, lang);
+                defResult = await readDefinition(word, lang);
             }
         }
 
-        const stats = isToday ? null : loadWordStats(lang, classicIdx);
+        const stats = isToday ? null : await loadWordStats(lang, classicIdx);
 
         words.push({
             day_idx: idx,

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
     });
 
     // Send email only if user exists and has a password (not Google-only)
-    if (user?.passwordHash) {
+    if (user?.passwordHash && user.email) {
         await sendPasswordResetEmail(user.id, user.email);
     }
 

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -56,7 +56,7 @@ export default defineEventHandler(async (event) => {
         },
     });
 
-    await sendVerificationEmail(user.id, user.email);
+    await sendVerificationEmail(user.id, user.email!);
 
     await setSessionForUser(event, user, 'email');
 

--- a/server/api/comments.get.ts
+++ b/server/api/comments.get.ts
@@ -1,0 +1,130 @@
+/**
+ * GET /api/comments — Fetch comments for a target, with real-time badges.
+ *
+ * Query params:
+ *   targetType  — 'word' | 'leaderboard'
+ *   targetKey   — e.g. 'en-hello', 'en-classic-1756'
+ *   appearances — comma-separated 'mode:dayIdx' pairs (e.g. 'classic:1756,quordle:42')
+ *                 Used to look up each commenter's game results for badge display.
+ *   lang        — language code (for result lookups)
+ *   limit       — page size (default 50, max 100)
+ *   cursor      — createdAt ISO string for cursor-based pagination
+ */
+import { prisma } from '~/server/utils/prisma';
+import { parseAppearances, type CommentBadge } from '~/server/utils/comments';
+
+interface CommentRow {
+    id: string;
+    body: string;
+    created_at: Date;
+    user_id: string | null;
+    username: string | null;
+    avatar_url: string | null;
+    badges: CommentBadge[] | null;
+}
+
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event);
+
+    const targetType = query.targetType as string;
+    const targetKey = query.targetKey as string;
+
+    if (!targetType || !targetKey) {
+        throw createError({ statusCode: 400, message: 'targetType and targetKey are required.' });
+    }
+
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit as string, 10) || 50));
+    const cursor = query.cursor as string | undefined;
+    const lang = query.lang as string || '';
+
+    const appearances = parseAppearances((query.appearances as string) || '');
+
+    const hasBadges = appearances.length > 0 && lang;
+
+    // Build the badges subquery — correlated per comment row
+    let badgesSubquery = 'NULL::json';
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    // Base WHERE params
+    params.push(targetType);    // $1
+    params.push(targetKey);     // $2
+    paramIdx = 3;
+
+    if (hasBadges) {
+        // Build the IN clause for (mode, day_idx) pairs
+        const pairs = appearances.map((a) => {
+            const modeParam = `$${paramIdx++}`;
+            const dayParam = `$${paramIdx++}`;
+            params.push(a.mode, a.dayIdx);
+            return `(${modeParam}, ${dayParam})`;
+        });
+        const langParam = `$${paramIdx++}`;
+        params.push(lang);
+
+        badgesSubquery = `(
+            SELECT json_agg(json_build_object(
+                'mode', r.mode, 'attempts', r.attempts, 'won', r.won
+            ))
+            FROM wordle.results r
+            WHERE r.user_id = c.user_id
+              AND r.lang = ${langParam}
+              AND r.play_type = 'daily'
+              AND r.won IS NOT NULL
+              AND (r.mode, r.day_idx) IN (${pairs.join(', ')})
+        )`;
+    }
+
+    // Cursor filter
+    let cursorClause = '';
+    if (cursor) {
+        const cursorDate = new Date(cursor);
+        if (isNaN(cursorDate.getTime())) {
+            throw createError({ statusCode: 400, message: 'Invalid cursor.' });
+        }
+        cursorClause = `AND c.created_at < $${paramIdx++}`;
+        params.push(cursorDate);
+    }
+
+    const limitParam = `$${paramIdx++}`;
+    params.push(limit);
+
+    const sql = `
+        SELECT
+            c.id, c.body, c.created_at, c.user_id,
+            u.username, u.avatar_url,
+            ${badgesSubquery} as badges
+        FROM wordle.comments c
+        LEFT JOIN wordle.users u ON c.user_id = u.id
+        WHERE c.type = 'comment'
+          AND c.target_type = $1
+          AND c.target_key = $2
+          AND c.hidden = false
+          ${cursorClause}
+        ORDER BY c.created_at DESC
+        LIMIT ${limitParam}
+    `;
+
+    // Skip count query on paginated requests — only needed on first page
+    const [rows, total] = await Promise.all([
+        prisma.$queryRawUnsafe<CommentRow[]>(sql, ...params),
+        cursor
+            ? Promise.resolve(-1)
+            : prisma.comment.count({
+                  where: { type: 'comment', targetType, targetKey, hidden: false },
+              }),
+    ]);
+
+    return {
+        comments: rows.map((r: CommentRow) => ({
+            id: r.id,
+            body: r.body,
+            username: r.username ?? 'Guest',
+            avatarUrl: r.avatar_url ?? null,
+            createdAt: r.created_at.toISOString(),
+            badges: (r.badges ?? []).slice(0, 3),
+        })),
+        total,
+        hasMore: rows.length === limit,
+    };
+});

--- a/server/api/comments.get.ts
+++ b/server/api/comments.get.ts
@@ -35,7 +35,7 @@ export default defineEventHandler(async (event) => {
 
     const limit = Math.min(100, Math.max(1, parseInt(query.limit as string, 10) || 50));
     const cursor = query.cursor as string | undefined;
-    const lang = query.lang as string || '';
+    const lang = (query.lang as string) || '';
 
     const appearances = parseAppearances((query.appearances as string) || '');
 
@@ -47,8 +47,8 @@ export default defineEventHandler(async (event) => {
     let paramIdx = 1;
 
     // Base WHERE params
-    params.push(targetType);    // $1
-    params.push(targetKey);     // $2
+    params.push(targetType); // $1
+    params.push(targetKey); // $2
     paramIdx = 3;
 
     if (hasBadges) {

--- a/server/api/comments.post.ts
+++ b/server/api/comments.post.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/comments — Create a comment.
+ *
+ * Requires authentication. Rate-limited: 5 per 10 minutes per user.
+ * Runs basic moderation (profanity, spam, URLs).
+ * Returns the new comment with real-time badges from the Results table.
+ */
+import { prisma } from '~/server/utils/prisma';
+import { rateLimit } from '~/server/utils/rate-limit';
+import { moderateComment } from '~/server/utils/moderation';
+import { parseAppearances, type CommentBadge } from '~/server/utils/comments';
+
+interface CommentBody {
+    targetType: string;
+    targetKey: string;
+    body: string;
+    /** Comma-separated 'mode:dayIdx' pairs for badge lookup */
+    appearances?: string;
+    lang?: string;
+}
+
+const VALID_TARGET_TYPES = ['word', 'leaderboard'];
+
+export default defineEventHandler(async (event) => {
+    // Auth required
+    const session = await getUserSession(event);
+    const userId = (session?.user as any)?.id;
+    if (!userId) {
+        throw createError({ statusCode: 401, message: 'Sign in to comment.' });
+    }
+
+    rateLimit(event, 'comments', 5, 10 * 60 * 1000);
+
+    const body = await readBody<CommentBody>(event);
+
+    if (!body.targetType || !VALID_TARGET_TYPES.includes(body.targetType)) {
+        throw createError({ statusCode: 400, message: 'Invalid target type.' });
+    }
+    if (!body.targetKey || typeof body.targetKey !== 'string') {
+        throw createError({ statusCode: 400, message: 'Target key is required.' });
+    }
+    if (!body.body || typeof body.body !== 'string') {
+        throw createError({ statusCode: 400, message: 'Comment body is required.' });
+    }
+
+    const text = body.body.trim().slice(0, 500);
+    if (text.length < 1) {
+        throw createError({ statusCode: 400, message: 'Comment is too short.' });
+    }
+
+    // Moderation check
+    const modResult = moderateComment(text);
+    if (!modResult.ok) {
+        throw createError({ statusCode: 422, message: modResult.reason! });
+    }
+
+    const comment = await prisma.comment.create({
+        data: {
+            userId,
+            type: 'comment',
+            targetType: body.targetType,
+            targetKey: body.targetKey,
+            body: text,
+        },
+        select: {
+            id: true,
+            body: true,
+            createdAt: true,
+            user: {
+                select: {
+                    username: true,
+                    avatarUrl: true,
+                },
+            },
+        },
+    });
+
+    let badges: CommentBadge[] = [];
+    const lang = body.lang || '';
+    const appearances = parseAppearances(body.appearances || '');
+
+    if (appearances.length > 0 && lang) {
+        const results = await prisma.result.findMany({
+            where: {
+                userId,
+                lang,
+                playType: 'daily',
+                won: { not: null },
+                OR: appearances.map((a) => ({
+                    mode: a.mode,
+                    dayIdx: a.dayIdx,
+                })),
+            },
+            select: { mode: true, attempts: true, won: true },
+        });
+        badges = results
+            .map((r: { mode: string; attempts: number | null; won: boolean | null }) => ({
+                mode: r.mode,
+                attempts: r.attempts ?? 0,
+                won: r.won ?? false,
+            }))
+            .slice(0, 3);
+    }
+
+    return {
+        id: comment.id,
+        body: comment.body,
+        username: comment.user?.username ?? 'Guest',
+        avatarUrl: comment.user?.avatarUrl ?? null,
+        createdAt: comment.createdAt.toISOString(),
+        badges,
+    };
+});

--- a/server/api/report.post.ts
+++ b/server/api/report.post.ts
@@ -1,0 +1,136 @@
+/**
+ * POST /api/report — Submit a bug report or feedback.
+ *
+ * Rate-limited: 3 per hour per IP. Stores in the comments table
+ * (type='report' or 'feedback'). Optionally emails the site owner
+ * via Resend if RESEND_API_KEY is configured.
+ */
+import { prisma } from '~/server/utils/prisma';
+import { rateLimit } from '~/server/utils/rate-limit';
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const REPORT_EMAIL = process.env.REPORT_EMAIL || 'hugo@wordle.global';
+
+interface ReportBody {
+    message: string;
+    type: 'bug' | 'feedback';
+    url?: string;
+    lang?: string;
+    mode?: string;
+    userAgent?: string;
+    screenSize?: string;
+    isPwa?: boolean;
+}
+
+export default defineEventHandler(async (event) => {
+    rateLimit(event, 'report', 3, 60 * 60 * 1000);
+
+    const body = await readBody<ReportBody>(event);
+
+    if (!body.message || typeof body.message !== 'string') {
+        throw createError({ statusCode: 400, message: 'Message is required.' });
+    }
+
+    const message = body.message.trim().slice(0, 2000);
+    if (message.length < 5) {
+        throw createError({ statusCode: 400, message: 'Message is too short.' });
+    }
+
+    // Optional auth — attach user if logged in
+    let userId: string | null = null;
+    let username: string | null = null;
+    let email: string | null = null;
+    try {
+        const session = await getUserSession(event);
+        const user = session?.user as any;
+        if (user?.id) {
+            userId = user.id;
+            username = user.displayName || null;
+            email = user.email || null;
+        }
+    } catch {
+        // Not logged in — that's fine
+    }
+
+    const type = body.type === 'feedback' ? 'feedback' : 'report';
+
+    // Store in database — this is the primary record
+    await prisma.comment.create({
+        data: {
+            userId,
+            type,
+            body: message,
+            metadata: {
+                url: body.url || null,
+                lang: body.lang || null,
+                mode: body.mode || null,
+                userAgent: body.userAgent || null,
+                screenSize: body.screenSize || null,
+                isPwa: body.isPwa ?? null,
+                username,
+                email,
+            },
+        },
+    });
+
+    // Optional email notification (best-effort, never blocks the response)
+    if (RESEND_API_KEY) {
+        sendNotificationEmail(type, message, body, username, email).catch((e) => {
+            console.error('[report] Email notification failed:', (e as Error).message);
+        });
+    }
+
+    return { ok: true };
+});
+
+async function sendNotificationEmail(
+    type: string,
+    message: string,
+    body: ReportBody,
+    username: string | null,
+    email: string | null
+) {
+    const typeLabel = type === 'report' ? '🐛 Bug Report' : '💬 Feedback';
+
+    const contextRows = [
+        body.url ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">URL</td><td style="padding:4px 0">${esc(body.url)}</td></tr>` : '',
+        body.lang ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Language</td><td style="padding:4px 0">${esc(body.lang)}</td></tr>` : '',
+        body.mode ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Mode</td><td style="padding:4px 0">${esc(body.mode)}</td></tr>` : '',
+        body.userAgent ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Browser</td><td style="padding:4px 0;font-size:12px;word-break:break-all">${esc(body.userAgent)}</td></tr>` : '',
+        body.screenSize ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Screen</td><td style="padding:4px 0">${esc(body.screenSize)}</td></tr>` : '',
+        body.isPwa != null ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">PWA</td><td style="padding:4px 0">${body.isPwa ? 'Yes' : 'No'}</td></tr>` : '',
+        username ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0">${esc(username)}${email ? ` (${esc(email)})` : ''}</td></tr>` : '<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0;color:#999">Guest</td></tr>',
+    ].filter(Boolean).join('\n');
+
+    const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px">
+    <h2 style="margin:0 0 16px;font-size:18px">${typeLabel}</h2>
+    <div style="background:#f8f8f8;border:1px solid #e0e0e0;padding:16px;margin-bottom:16px;white-space:pre-wrap;font-size:14px;line-height:1.6">${esc(message)}</div>
+    <table style="font-size:13px;border-collapse:collapse">
+        ${contextRows}
+    </table>
+    <hr style="border:none;border-top:1px solid #e0e0e0;margin:20px 0 12px" />
+    <p style="font-size:11px;color:#999;margin:0">Sent from wordle.global in-app report</p>
+</div>`;
+
+    const subject = `[Wordle] ${typeLabel}: ${message.slice(0, 60)}${message.length > 60 ? '…' : ''}`;
+
+    const { Resend } = await import('resend');
+    const resend = new Resend(RESEND_API_KEY);
+    await resend.emails.send({
+        from: 'Wordle Global <noreply@wordle.global>',
+        to: REPORT_EMAIL,
+        replyTo: email || undefined,
+        subject,
+        html,
+    });
+}
+
+function esc(str: string): string {
+    return str
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/server/api/report.post.ts
+++ b/server/api/report.post.ts
@@ -93,14 +93,30 @@ async function sendNotificationEmail(
     const typeLabel = type === 'report' ? '🐛 Bug Report' : '💬 Feedback';
 
     const contextRows = [
-        body.url ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">URL</td><td style="padding:4px 0">${esc(body.url)}</td></tr>` : '',
-        body.lang ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Language</td><td style="padding:4px 0">${esc(body.lang)}</td></tr>` : '',
-        body.mode ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Mode</td><td style="padding:4px 0">${esc(body.mode)}</td></tr>` : '',
-        body.userAgent ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Browser</td><td style="padding:4px 0;font-size:12px;word-break:break-all">${esc(body.userAgent)}</td></tr>` : '',
-        body.screenSize ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Screen</td><td style="padding:4px 0">${esc(body.screenSize)}</td></tr>` : '',
-        body.isPwa != null ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">PWA</td><td style="padding:4px 0">${body.isPwa ? 'Yes' : 'No'}</td></tr>` : '',
-        username ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0">${esc(username)}${email ? ` (${esc(email)})` : ''}</td></tr>` : '<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0;color:#999">Guest</td></tr>',
-    ].filter(Boolean).join('\n');
+        body.url
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">URL</td><td style="padding:4px 0">${esc(body.url)}</td></tr>`
+            : '',
+        body.lang
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Language</td><td style="padding:4px 0">${esc(body.lang)}</td></tr>`
+            : '',
+        body.mode
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Mode</td><td style="padding:4px 0">${esc(body.mode)}</td></tr>`
+            : '',
+        body.userAgent
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Browser</td><td style="padding:4px 0;font-size:12px;word-break:break-all">${esc(body.userAgent)}</td></tr>`
+            : '',
+        body.screenSize
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">Screen</td><td style="padding:4px 0">${esc(body.screenSize)}</td></tr>`
+            : '',
+        body.isPwa != null
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">PWA</td><td style="padding:4px 0">${body.isPwa ? 'Yes' : 'No'}</td></tr>`
+            : '',
+        username
+            ? `<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0">${esc(username)}${email ? ` (${esc(email)})` : ''}</td></tr>`
+            : '<tr><td style="padding:4px 12px 4px 0;color:#666;white-space:nowrap">User</td><td style="padding:4px 0;color:#999">Guest</td></tr>',
+    ]
+        .filter(Boolean)
+        .join('\n');
 
     const html = `
 <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px">

--- a/server/api/user/game-result.post.ts
+++ b/server/api/user/game-result.post.ts
@@ -108,14 +108,14 @@ export default defineEventHandler(async (event) => {
 
             // Create UserBadge rows
             await prisma.userBadge.createMany({
-                data: badges.map((b) => ({
+                data: badges.map((b: { id: string; slug: string; name: string; description: string; icon: string }) => ({
                     userId,
                     badgeId: b.id,
                 })),
                 skipDuplicates: true,
             });
 
-            newBadges = badges.map((b) => ({
+            newBadges = badges.map((b: { id: string; slug: string; name: string; description: string; icon: string }) => ({
                 slug: b.slug,
                 name: b.name,
                 description: b.description,

--- a/server/api/user/game-result.post.ts
+++ b/server/api/user/game-result.post.ts
@@ -108,19 +108,35 @@ export default defineEventHandler(async (event) => {
 
             // Create UserBadge rows
             await prisma.userBadge.createMany({
-                data: badges.map((b: { id: string; slug: string; name: string; description: string; icon: string }) => ({
-                    userId,
-                    badgeId: b.id,
-                })),
+                data: badges.map(
+                    (b: {
+                        id: string;
+                        slug: string;
+                        name: string;
+                        description: string;
+                        icon: string;
+                    }) => ({
+                        userId,
+                        badgeId: b.id,
+                    })
+                ),
                 skipDuplicates: true,
             });
 
-            newBadges = badges.map((b: { id: string; slug: string; name: string; description: string; icon: string }) => ({
-                slug: b.slug,
-                name: b.name,
-                description: b.description,
-                icon: b.icon,
-            }));
+            newBadges = badges.map(
+                (b: {
+                    id: string;
+                    slug: string;
+                    name: string;
+                    description: string;
+                    icon: string;
+                }) => ({
+                    slug: b.slug,
+                    name: b.name,
+                    description: b.description,
+                    icon: b.icon,
+                })
+            );
         }
     } catch (e) {
         // Badge evaluation is non-critical — don't fail the game result save

--- a/server/api/user/profile.get.ts
+++ b/server/api/user/profile.get.ts
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
         email: user.email,
         createdAt: user.createdAt,
         settings: user.settings,
-        badges: user.badges.map((ub) => ({
+        badges: user.badges.map((ub: { badge: { slug: string; name: string; description: string; category: string; icon: string }; earnedAt: Date }) => ({
             slug: ub.badge.slug,
             name: ub.badge.name,
             description: ub.badge.description,

--- a/server/api/user/profile.get.ts
+++ b/server/api/user/profile.get.ts
@@ -25,14 +25,25 @@ export default defineEventHandler(async (event) => {
         email: user.email,
         createdAt: user.createdAt,
         settings: user.settings,
-        badges: user.badges.map((ub: { badge: { slug: string; name: string; description: string; category: string; icon: string }; earnedAt: Date }) => ({
-            slug: ub.badge.slug,
-            name: ub.badge.name,
-            description: ub.badge.description,
-            category: ub.badge.category,
-            icon: ub.badge.icon,
-            earnedAt: ub.earnedAt,
-        })),
+        badges: user.badges.map(
+            (ub: {
+                badge: {
+                    slug: string;
+                    name: string;
+                    description: string;
+                    category: string;
+                    icon: string;
+                };
+                earnedAt: Date;
+            }) => ({
+                slug: ub.badge.slug,
+                name: ub.badge.name,
+                description: ub.badge.description,
+                category: ub.badge.category,
+                icon: ub.badge.icon,
+                earnedAt: ub.earnedAt,
+            })
+        ),
         isPro: user.subscription?.status === 'active',
     };
 });

--- a/server/api/user/sync.post.ts
+++ b/server/api/user/sync.post.ts
@@ -61,7 +61,7 @@ export default defineEventHandler(async (event) => {
 
     // --- Game results (classic, dordle, quordle, semantic, etc.) ---
     if (body.gameResults && typeof body.gameResults === 'object') {
-        const rows: Parameters<typeof prisma.result.createMany>[0]['data'] = [];
+        const rows: NonNullable<Parameters<typeof prisma.result.createMany>[0]>['data'] = [];
 
         for (const [statsKey, results] of Object.entries(body.gameResults)) {
             if (!Array.isArray(results)) continue;
@@ -97,7 +97,7 @@ export default defineEventHandler(async (event) => {
 
     // --- Speed results ---
     if (body.speedResults && typeof body.speedResults === 'object') {
-        const rows: Parameters<typeof prisma.result.createMany>[0]['data'] = [];
+        const rows: NonNullable<Parameters<typeof prisma.result.createMany>[0]>['data'] = [];
 
         for (const [langCode, results] of Object.entries(body.speedResults)) {
             if (!Array.isArray(results)) continue;
@@ -156,7 +156,7 @@ export default defineEventHandler(async (event) => {
                 select: { id: true },
             });
             await prisma.userBadge.createMany({
-                data: badges.map((b) => ({ userId, badgeId: b.id })),
+                data: badges.map((b: { id: string }) => ({ userId, badgeId: b.id })),
                 skipDuplicates: true,
             });
         }

--- a/server/api/webauthn/authenticate.post.ts
+++ b/server/api/webauthn/authenticate.post.ts
@@ -22,10 +22,12 @@ export default defineWebAuthnAuthenticateEventHandler({
             throw createError({ statusCode: 400, message: 'User not found' });
         }
 
-        return user.credentials.map((c: { credentialId: string; transports: string | string[] }) => ({
-            id: c.credentialId,
-            transports: c.transports as AuthenticatorTransportFuture[],
-        }));
+        return user.credentials.map(
+            (c: { credentialId: string; transports: string | string[] }) => ({
+                id: c.credentialId,
+                transports: c.transports as AuthenticatorTransportFuture[],
+            })
+        );
     },
     async getCredential(event, credentialId) {
         const cred = await prisma.credential.findUnique({

--- a/server/api/webauthn/authenticate.post.ts
+++ b/server/api/webauthn/authenticate.post.ts
@@ -3,12 +3,18 @@
  *
  * Following the official nuxt-auth-utils playground pattern.
  */
+import type { AuthenticatorTransportFuture } from '@simplewebauthn/server';
 import { prisma } from '~/server/utils/prisma';
 
 export default defineWebAuthnAuthenticateEventHandler({
     async allowCredentials(event, userName) {
-        const user = await prisma.user.findUnique({
-            where: { email: userName },
+        // Look up by username (passkey users have null email).
+        // For discoverable credential / conditional mediation flow,
+        // the library skips this callback entirely when userName is empty.
+        const user = await prisma.user.findFirst({
+            where: {
+                OR: [{ username: userName }, { email: userName }],
+            },
             include: { credentials: true },
         });
 
@@ -16,9 +22,9 @@ export default defineWebAuthnAuthenticateEventHandler({
             throw createError({ statusCode: 400, message: 'User not found' });
         }
 
-        return user.credentials.map((c) => ({
+        return user.credentials.map((c: { credentialId: string; transports: string | string[] }) => ({
             id: c.credentialId,
-            transports: c.transports as string[],
+            transports: c.transports as AuthenticatorTransportFuture[],
         }));
     },
     async getCredential(event, credentialId) {

--- a/server/api/webauthn/register.post.ts
+++ b/server/api/webauthn/register.post.ts
@@ -13,6 +13,16 @@ import { prisma } from '~/server/utils/prisma';
 import { sanitizeUsername, generateUniqueUsername } from '~/server/utils/name-generator';
 
 export default defineWebAuthnRegisterEventHandler({
+    // Force platform authenticator (Face ID / Touch ID) and make credential discoverable
+    async getOptions() {
+        return {
+            authenticatorSelection: {
+                authenticatorAttachment: 'platform' as const,
+                residentKey: 'required' as const,
+                userVerification: 'preferred' as const,
+            },
+        };
+    },
     async validateUser(userBody, event) {
         const session = await getUserSession(event);
 

--- a/server/routes/auth/google.get.ts
+++ b/server/routes/auth/google.get.ts
@@ -19,7 +19,12 @@ export default defineOAuthGoogleEventHandler({
     config: {
         scope: ['openid', 'email', 'profile'],
     },
-    async onSuccess(event, { user: googleUser }: { user: { sub: string; email: string; name: string; picture: string } }) {
+    async onSuccess(
+        event,
+        {
+            user: googleUser,
+        }: { user: { sub: string; email: string; name: string; picture: string } }
+    ) {
         // Check if user already exists (returning login)
         let user = await withRetry(() =>
             prisma.user.findUnique({ where: { googleId: googleUser.sub } })

--- a/server/routes/auth/google.get.ts
+++ b/server/routes/auth/google.get.ts
@@ -19,7 +19,7 @@ export default defineOAuthGoogleEventHandler({
     config: {
         scope: ['openid', 'email', 'profile'],
     },
-    async onSuccess(event, { user: googleUser }) {
+    async onSuccess(event, { user: googleUser }: { user: { sub: string; email: string; name: string; picture: string } }) {
         // Check if user already exists (returning login)
         let user = await withRetry(() =>
             prisma.user.findUnique({ where: { googleId: googleUser.sub } })

--- a/server/utils/_semantic-db.ts
+++ b/server/utils/_semantic-db.ts
@@ -52,7 +52,7 @@ export async function loadAxes(lang: string = 'en'): Promise<AxisData[]> {
     >`SELECT name, low_anchor, high_anchor, vector::text, auc, range_p5, range_p95
       FROM wordle.semantic_axes WHERE lang = ${lang} ORDER BY name`;
 
-    const axes: AxisData[] = rows.map((r) => ({
+    const axes: AxisData[] = rows.map((r: { name: string; low_anchor: string; high_anchor: string; vector: string; auc: number | null; range_p5: number | null; range_p95: number | null }) => ({
         name: r.name,
         lowAnchor: r.low_anchor,
         highAnchor: r.high_anchor,
@@ -318,7 +318,7 @@ export async function batchGetRanks(
             SELECT word, rank FROM wordle.target_neighbors
             WHERE lang = ${lang} AND target_word = ${target} AND word = ANY(${words}::text[])
         `;
-        return new Map(rows.map((r) => [r.word, r.rank]));
+        return new Map(rows.map((r: { word: string; rank: number }) => [r.word, r.rank]));
     } catch {
         return new Map();
     }
@@ -397,7 +397,7 @@ export async function knnNearestByVector(
             ORDER BY embedding <=> ${vecStr}::vector
             LIMIT ${k}
         `;
-        return rows.map((r) => ({
+        return rows.map((r: { word: string; similarity: number; umap_x: number | null; umap_y: number | null; pca2d_x: number | null; pca2d_y: number | null }) => ({
             word: r.word,
             similarity: r.similarity,
             umapX: r.umap_x ?? undefined,
@@ -425,7 +425,7 @@ export async function getTargets(lang: string): Promise<string[]> {
             WHERE lang = ${lang} AND is_target = true
             ORDER BY word
         `;
-        const targets = rows.map((r) => r.word);
+        const targets = rows.map((r: { word: string }) => r.word);
         _targetsCache.set(lang, targets);
         return targets;
     } catch {

--- a/server/utils/_semantic-db.ts
+++ b/server/utils/_semantic-db.ts
@@ -52,15 +52,25 @@ export async function loadAxes(lang: string = 'en'): Promise<AxisData[]> {
     >`SELECT name, low_anchor, high_anchor, vector::text, auc, range_p5, range_p95
       FROM wordle.semantic_axes WHERE lang = ${lang} ORDER BY name`;
 
-    const axes: AxisData[] = rows.map((r: { name: string; low_anchor: string; high_anchor: string; vector: string; auc: number | null; range_p5: number | null; range_p95: number | null }) => ({
-        name: r.name,
-        lowAnchor: r.low_anchor,
-        highAnchor: r.high_anchor,
-        vector: parseVector(r.vector),
-        auc: r.auc ?? 0,
-        rangeP5: r.range_p5 ?? 0,
-        rangeP95: r.range_p95 ?? 0,
-    }));
+    const axes: AxisData[] = rows.map(
+        (r: {
+            name: string;
+            low_anchor: string;
+            high_anchor: string;
+            vector: string;
+            auc: number | null;
+            range_p5: number | null;
+            range_p95: number | null;
+        }) => ({
+            name: r.name,
+            lowAnchor: r.low_anchor,
+            highAnchor: r.high_anchor,
+            vector: parseVector(r.vector),
+            auc: r.auc ?? 0,
+            rangeP5: r.range_p5 ?? 0,
+            rangeP95: r.range_p95 ?? 0,
+        })
+    );
 
     const dims = axes[0]?.vector.length ?? EMBEDDING_DIMS;
     const axesVectors = new Float32Array(axes.length * dims);
@@ -397,14 +407,23 @@ export async function knnNearestByVector(
             ORDER BY embedding <=> ${vecStr}::vector
             LIMIT ${k}
         `;
-        return rows.map((r: { word: string; similarity: number; umap_x: number | null; umap_y: number | null; pca2d_x: number | null; pca2d_y: number | null }) => ({
-            word: r.word,
-            similarity: r.similarity,
-            umapX: r.umap_x ?? undefined,
-            umapY: r.umap_y ?? undefined,
-            pca2dX: r.pca2d_x ?? undefined,
-            pca2dY: r.pca2d_y ?? undefined,
-        }));
+        return rows.map(
+            (r: {
+                word: string;
+                similarity: number;
+                umap_x: number | null;
+                umap_y: number | null;
+                pca2d_x: number | null;
+                pca2d_y: number | null;
+            }) => ({
+                word: r.word,
+                similarity: r.similarity,
+                umapX: r.umap_x ?? undefined,
+                umapY: r.umap_y ?? undefined,
+                pca2dX: r.pca2d_x ?? undefined,
+                pca2dY: r.pca2d_y ?? undefined,
+            })
+        );
     } catch (e) {
         console.warn('[semantic-db] knnNearest failed:', e);
         return [];

--- a/server/utils/badge-evaluator.ts
+++ b/server/utils/badge-evaluator.ts
@@ -22,7 +22,7 @@ export async function evaluateBadges(userId: string, result: GameResultContext):
         where: { userId },
         select: { badge: { select: { slug: true } } },
     });
-    const earned = new Set(existingBadges.map((ub) => ub.badge.slug));
+    const earned = new Set(existingBadges.map((ub: { badge: { slug: string } }) => ub.badge.slug));
 
     const newBadges: string[] = [];
 
@@ -132,7 +132,7 @@ export async function computeBadgeProgress(userId: string): Promise<Record<strin
         'first-blood': totalWins,
         polyglot: distinctLangs.length,
         streak: streak,
-        mode: Math.max(0, ...modeCounts.map((m) => m._count)),
+        mode: Math.max(0, ...modeCounts.map((m: { mode: string; _count: number }) => m._count)),
     };
 }
 

--- a/server/utils/comments.ts
+++ b/server/utils/comments.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared utilities for the comments system — badge types, appearance parsing.
+ */
+
+export interface CommentBadge {
+    mode: string;
+    attempts: number;
+    won: boolean;
+}
+
+export interface ParsedAppearance {
+    mode: string;
+    dayIdx: number;
+}
+
+/** Parse "classic:1756,quordle:42" → structured appearances array (capped at 20) */
+export function parseAppearances(raw: string): ParsedAppearance[] {
+    return raw
+        .split(',')
+        .map((a) => a.trim())
+        .filter(Boolean)
+        .slice(0, 20)
+        .map((a) => {
+            const [mode, dayStr] = a.split(':');
+            return { mode: mode!, dayIdx: parseInt(dayStr!, 10) };
+        })
+        .filter((a) => a.mode && !isNaN(a.dayIdx));
+}

--- a/server/utils/definitions.ts
+++ b/server/utils/definitions.ts
@@ -219,21 +219,48 @@ export async function fetchDefinition(
     // --- DB cache (includes LLM, kaikki, and kaikki-en definitions) ---
     const dbResult = dbCache ? await dbCache.getDefinition(langCode, word.toLowerCase()) : null;
     if (dbResult) {
-        if (dbResult.isNegative && !options.skipNegativeCache) return null;
-        if (!dbResult.isNegative) {
+        // Negative cache entries: skip if kaikki senses exist (don't let a
+        // failed LLM call block richer structured data)
+        if (dbResult.isNegative && !options.skipNegativeCache) {
+            // Check if structured kaikki data exists despite the negative flag
+            const row = dbResult as Record<string, any>;
+            if (!row.senses) return null;
+            // Fall through — senses exist, derive definition below
+        }
+
+        if (!dbResult.isNegative || (dbResult as Record<string, any>).senses) {
             // kaikki-en fallback entries expire after 24h so LLM can retry
             const isStaleKaikkiEn =
                 dbResult.source === 'kaikki-en' &&
                 !dbResult.definitionNative &&
                 Date.now() - dbResult.cachedAt.getTime() >= NEGATIVE_CACHE_TTL * 1000;
-            if (!isStaleKaikkiEn) {
+
+            // Derive definition from structured senses when no LLM definition
+            let definition = dbResult.definition;
+            let definitionNative = dbResult.definitionNative;
+            let partOfSpeech = dbResult.partOfSpeech;
+            const senses = (dbResult as Record<string, any>).senses;
+
+            if (!definition && senses && Array.isArray(senses)) {
+                // Extract first gloss from first POS entry
+                for (const entry of senses) {
+                    const glosses = entry?.glosses;
+                    if (Array.isArray(glosses) && glosses.length > 0) {
+                        definition = glosses[0]?.gloss || null;
+                        if (!partOfSpeech) partOfSpeech = entry.pos || null;
+                        break;
+                    }
+                }
+            }
+
+            if ((definition || definitionNative) && !isStaleKaikkiEn) {
                 return {
-                    definition: dbResult.definition,
-                    definition_native: dbResult.definitionNative,
+                    definition,
+                    definition_native: definitionNative,
                     definition_en: dbResult.definitionEn,
-                    part_of_speech: dbResult.partOfSpeech,
+                    part_of_speech: partOfSpeech,
                     confidence: dbResult.confidence,
-                    source: dbResult.source,
+                    source: dbResult.source || 'kaikki',
                     url: dbResult.url,
                 };
             }
@@ -248,28 +275,32 @@ export async function fetchDefinition(
     const result = await dedup('definition', dedupKey, async () => {
         const llmResult = await callLlmDefinition(word, langCode);
 
-        // Cache result to DB
+        // Cache result to DB — but never overwrite kaikki senses with a negative entry
         const isNeg = !llmResult;
-        try {
-            await dbCache?.upsertDefinition(
-                langCode,
-                word.toLowerCase(),
-                llmResult
-                    ? {
-                          definition: llmResult.definition,
-                          definitionNative: llmResult.definition_native,
-                          definitionEn: llmResult.definition_en,
-                          partOfSpeech: llmResult.part_of_speech,
-                          confidence: llmResult.confidence,
-                          source: llmResult.source,
-                          model: LLM_MODEL,
-                          url: llmResult.url,
-                      }
-                    : {},
-                isNeg
-            );
-        } catch (e) {
-            consola.warn(`[definitions] DB write failed for ${langCode}/${word}:`, e);
+        if (isNeg && dbResult && (dbResult as Record<string, any>).senses) {
+            // Kaikki data exists — don't write negative over it
+        } else {
+            try {
+                await dbCache?.upsertDefinition(
+                    langCode,
+                    word.toLowerCase(),
+                    llmResult
+                        ? {
+                              definition: llmResult.definition,
+                              definitionNative: llmResult.definition_native,
+                              definitionEn: llmResult.definition_en,
+                              partOfSpeech: llmResult.part_of_speech,
+                              confidence: llmResult.confidence,
+                              source: llmResult.source,
+                              model: LLM_MODEL,
+                              url: llmResult.url,
+                          }
+                        : {},
+                    isNeg
+                );
+            } catch (e) {
+                consola.warn(`[definitions] DB write failed for ${langCode}/${word}:`, e);
+            }
         }
 
         return llmResult;

--- a/server/utils/moderation.ts
+++ b/server/utils/moderation.ts
@@ -13,18 +13,44 @@
 // so "assess" doesn't trigger on "ass", "scunthorpe" doesn't trigger on "cunt", etc.
 const BLOCKED_WORDS = [
     // Slurs & hate speech
-    'nigger', 'nigga', 'faggot', 'fag', 'retard', 'tranny', 'kike', 'chink', 'spic', 'wetback',
+    'nigger',
+    'nigga',
+    'faggot',
+    'fag',
+    'retard',
+    'tranny',
+    'kike',
+    'chink',
+    'spic',
+    'wetback',
     // Sexual
-    'fuck', 'fucker', 'fucking', 'motherfucker', 'shit', 'shitty', 'bullshit',
-    'cunt', 'dick', 'cock', 'pussy', 'whore', 'slut', 'bitch',
-    'porn', 'hentai', 'dildo', 'blowjob', 'handjob',
+    'fuck',
+    'fucker',
+    'fucking',
+    'motherfucker',
+    'shit',
+    'shitty',
+    'bullshit',
+    'cunt',
+    'dick',
+    'cock',
+    'pussy',
+    'whore',
+    'slut',
+    'bitch',
+    'porn',
+    'hentai',
+    'dildo',
+    'blowjob',
+    'handjob',
     // Threats / violence
-    'kill yourself', 'kys',
+    'kill yourself',
+    'kys',
 ];
 
 // Build a single regex: match any blocked word at word boundaries (case-insensitive)
 const BLOCKED_RE = new RegExp(
-    '\\b(' + BLOCKED_WORDS.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|') + ')\\b',
+    '\\b(' + BLOCKED_WORDS.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|') + ')\\b',
     'i'
 );
 
@@ -52,7 +78,7 @@ export function moderateComment(text: string): ModerationResult {
     }
 
     if (EXCESSIVE_CAPS_RE.test(text) && text.length > 30) {
-        return { ok: false, reason: 'Please don\'t write in all caps.' };
+        return { ok: false, reason: "Please don't write in all caps." };
     }
 
     return { ok: true };

--- a/server/utils/moderation.ts
+++ b/server/utils/moderation.ts
@@ -1,0 +1,59 @@
+/**
+ * Lightweight text moderation for user-submitted comments.
+ *
+ * Strategy: regex word-boundary match against a compact English blocklist.
+ * This catches the most common abuse in the lingua franca of the internet.
+ * It's not comprehensive for 80 languages — manual moderation via the
+ * `hidden` flag covers the long tail.
+ *
+ * Returns { ok: true } or { ok: false, reason: string }.
+ */
+
+// Words that should never appear in a comment. Matched with word boundaries
+// so "assess" doesn't trigger on "ass", "scunthorpe" doesn't trigger on "cunt", etc.
+const BLOCKED_WORDS = [
+    // Slurs & hate speech
+    'nigger', 'nigga', 'faggot', 'fag', 'retard', 'tranny', 'kike', 'chink', 'spic', 'wetback',
+    // Sexual
+    'fuck', 'fucker', 'fucking', 'motherfucker', 'shit', 'shitty', 'bullshit',
+    'cunt', 'dick', 'cock', 'pussy', 'whore', 'slut', 'bitch',
+    'porn', 'hentai', 'dildo', 'blowjob', 'handjob',
+    // Threats / violence
+    'kill yourself', 'kys',
+];
+
+// Build a single regex: match any blocked word at word boundaries (case-insensitive)
+const BLOCKED_RE = new RegExp(
+    '\\b(' + BLOCKED_WORDS.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|') + ')\\b',
+    'i'
+);
+
+// Detect spam patterns: URLs, repeated characters, ALL CAPS abuse
+const URL_RE = /https?:\/\/|www\./i;
+const REPEATED_CHAR_RE = /(.)\1{7,}/; // 8+ repeated chars
+const EXCESSIVE_CAPS_RE = /^[^a-z]*[A-Z\s!?.]{30,}$/; // 30+ chars of all caps
+
+export interface ModerationResult {
+    ok: boolean;
+    reason?: string;
+}
+
+export function moderateComment(text: string): ModerationResult {
+    if (BLOCKED_RE.test(text)) {
+        return { ok: false, reason: 'Your comment contains inappropriate language.' };
+    }
+
+    if (URL_RE.test(text)) {
+        return { ok: false, reason: 'Links are not allowed in comments.' };
+    }
+
+    if (REPEATED_CHAR_RE.test(text)) {
+        return { ok: false, reason: 'Your comment contains too many repeated characters.' };
+    }
+
+    if (EXCESSIVE_CAPS_RE.test(text) && text.length > 30) {
+        return { ok: false, reason: 'Please don\'t write in all caps.' };
+    }
+
+    return { ok: true };
+}

--- a/server/utils/name-generator.ts
+++ b/server/utils/name-generator.ts
@@ -44,7 +44,7 @@ export async function generateUniqueUsername(base: string): Promise<string> {
         where: { username: { startsWith: sanitized } },
         select: { username: true },
     });
-    const takenSet = new Set(taken.map((u) => u.username));
+    const takenSet = new Set(taken.map((u: { username: string }) => u.username));
 
     if (!takenSet.has(sanitized)) return sanitized;
 

--- a/server/utils/prisma.ts
+++ b/server/utils/prisma.ts
@@ -9,9 +9,9 @@ import pg from 'pg';
 // Singleton PrismaClient — reused across all Nitro handlers.
 // In development, Nitro hot-reloads server code; storing on globalThis
 // prevents leaked connections from stale module instances.
-const globalForPrisma = globalThis as unknown as { __prisma?: PrismaClient };
+const globalForPrisma = globalThis as unknown as { __prisma?: InstanceType<typeof PrismaClient> };
 
-function createClient(): PrismaClient {
+function createClient(): InstanceType<typeof PrismaClient> {
     const connectionString = process.env.DATABASE_URL;
     if (!connectionString) {
         console.warn('[prisma] DATABASE_URL not set — database features disabled');
@@ -41,7 +41,7 @@ function createClient(): PrismaClient {
     });
 }
 
-export const prisma: PrismaClient = globalForPrisma.__prisma ?? createClient();
+export const prisma: InstanceType<typeof PrismaClient> = globalForPrisma.__prisma ?? createClient();
 
 if (process.env.NODE_ENV !== 'production') {
     globalForPrisma.__prisma = prisma;

--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -65,7 +65,7 @@ export function rateLimit(
     entry.count++;
     if (entry.count > maxRequests) {
         const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-        setResponseHeader(event, 'Retry-After', String(retryAfter));
+        setResponseHeader(event, 'Retry-After', retryAfter);
         throw createError({
             statusCode: 429,
             message: 'Too many requests. Please try again later.',

--- a/server/utils/word-selection.ts
+++ b/server/utils/word-selection.ts
@@ -295,7 +295,13 @@ const _modeReverseCache = new Map<string, ModeReverseIndex>();
 
 /** Modes that use 1-based mode day indices starting April 11 2026. */
 const USES_MODE_DAY_IDX = new Set([
-    'dordle', 'quordle', 'octordle', 'sedecordle', 'duotrigordle', 'speed', 'semantic',
+    'dordle',
+    'quordle',
+    'octordle',
+    'sedecordle',
+    'duotrigordle',
+    'speed',
+    'semantic',
 ]);
 
 function ensureModeReverseIndex(langCode: string, mode: string): ModeReverseIndex {
@@ -334,9 +340,10 @@ function ensureModeReverseIndex(langCode: string, mode: string): ModeReverseInde
         }
 
         for (let b = 0; b < boardCount; b++) {
-            const slotIdx = b === 0
-                ? classicIdx + modeOffset
-                : classicIdx + modeOffset + b * MULTI_BOARD_SLOT_OFFSET;
+            const slotIdx =
+                b === 0
+                    ? classicIdx + modeOffset
+                    : classicIdx + modeOffset + b * MULTI_BOARD_SLOT_OFFSET;
             const slotH = dayHash(slotIdx, langCode);
             const selected = ringSelect(ring, slotH, exclude);
             if (selected) {

--- a/server/utils/word-selection.ts
+++ b/server/utils/word-selection.ts
@@ -14,10 +14,11 @@ import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
 import { join } from 'path';
 import { MIGRATION_DAY_IDX, WORD_HISTORY_DIR, loadAllData } from './data-loader';
+import { toModeDayIdx, fromModeDayIdx } from '../lib/day-index';
 
 // Re-export day index functions so existing consumers don't need to change imports
 export { getTodaysIdx, idxToDate } from '../lib/day-index';
-import { getTodaysIdx } from '../lib/day-index';
+import { getTodaysIdx, idxToDate } from '../lib/day-index';
 
 const RECENCY_WINDOW = 60;
 const EMPTY_SET: Set<string> = new Set();
@@ -257,6 +258,144 @@ export function iterateHistoricalWords(langCode: string): Array<{ dayIdx: number
     }));
     entries.sort((a, b) => b.dayIdx - a.dayIdx);
     return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Cross-mode word appearances
+// ---------------------------------------------------------------------------
+
+export type WordAppearance = {
+    mode: string;
+    dayIdx: number;
+    date: string;
+    board?: number; // 0-indexed board slot for multi-board modes
+};
+
+const MODE_BOARD_COUNTS: Record<string, number> = {
+    classic: 1,
+    dordle: 2,
+    quordle: 4,
+    octordle: 8,
+    sedecordle: 16,
+    duotrigordle: 32,
+    speed: 1,
+};
+
+/**
+ * Lazy per-mode reverse index: word → { modeDayIdx, classicDayIdx, board }.
+ * Built once per (lang, mode) by replaying the deterministic hash selection.
+ * Pure in-memory — no disk writes.
+ *
+ * Non-classic modes launched April 11 2026. They use 1-based mode day indices
+ * (day 1 = April 11). Classic uses its own historical index (day 1 = 2021).
+ */
+type ModeReverseEntry = { modeDayIdx: number; classicDayIdx: number; board: number };
+type ModeReverseIndex = { built: number; map: Map<string, ModeReverseEntry> };
+const _modeReverseCache = new Map<string, ModeReverseIndex>();
+
+/** Modes that use 1-based mode day indices starting April 11 2026. */
+const USES_MODE_DAY_IDX = new Set([
+    'dordle', 'quordle', 'octordle', 'sedecordle', 'duotrigordle', 'speed', 'semantic',
+]);
+
+function ensureModeReverseIndex(langCode: string, mode: string): ModeReverseIndex {
+    const cacheKey = `${langCode}:${mode}`;
+    const classicToday = getTodaysIdx();
+    let cached = _modeReverseCache.get(cacheKey);
+
+    // Determine the classic day index range to scan
+    const usesModeDayIdx = USES_MODE_DAY_IDX.has(mode);
+    const startClassicIdx = usesModeDayIdx
+        ? fromModeDayIdx(1) // classic index of mode day 1
+        : MIGRATION_DAY_IDX + 1;
+
+    if (!cached) {
+        cached = { built: startClassicIdx - 1, map: new Map() };
+        _modeReverseCache.set(cacheKey, cached);
+    }
+    if (cached.built >= classicToday) return cached;
+
+    const data = loadAllData();
+    const dailyWords = data.dailyWords[langCode];
+    const pool = dailyWords && dailyWords.length > 0 ? dailyWords : data.wordLists[langCode]!;
+    if (!pool || pool.length === 0) return cached;
+
+    const blocklist = data.blocklists[langCode]!;
+    const ring = getHashRing(pool, langCode);
+    const modeOffset = MODE_SLOT_OFFSETS[mode] ?? 0;
+    const boardCount = MODE_BOARD_COUNTS[mode] ?? 1;
+    const recentWords: string[] = [];
+
+    const scanStart = Math.max(cached.built + 1, startClassicIdx);
+    for (let classicIdx = scanStart; classicIdx <= classicToday; classicIdx++) {
+        const exclude = new Set<string>(blocklist);
+        for (const rw of recentWords.slice(-RECENCY_WINDOW)) {
+            exclude.add(rw);
+        }
+
+        for (let b = 0; b < boardCount; b++) {
+            const slotIdx = b === 0
+                ? classicIdx + modeOffset
+                : classicIdx + modeOffset + b * MULTI_BOARD_SLOT_OFFSET;
+            const slotH = dayHash(slotIdx, langCode);
+            const selected = ringSelect(ring, slotH, exclude);
+            if (selected) {
+                exclude.add(selected);
+                recentWords.push(selected);
+                if (!cached.map.has(selected)) {
+                    const modeDayIdx = usesModeDayIdx
+                        ? (toModeDayIdx(classicIdx) ?? classicIdx)
+                        : classicIdx;
+                    cached.map.set(selected, {
+                        modeDayIdx,
+                        classicDayIdx: classicIdx,
+                        board: b,
+                    });
+                }
+            }
+        }
+    }
+    cached.built = classicToday;
+    return cached;
+}
+
+/**
+ * Find all game modes where a word appeared as a daily word.
+ * Classic uses the existing reverse index. Other modes use
+ * per-mode reverse indices built via in-memory hash computation.
+ */
+export function findWordAppearances(langCode: string, word: string): WordAppearance[] {
+    const w = word.toLowerCase();
+    const appearances: WordAppearance[] = [];
+
+    // Classic: O(1) via existing reverse index
+    const classicDay = getDayForWord(langCode, w);
+    if (classicDay != null) {
+        appearances.push({
+            mode: 'classic',
+            dayIdx: classicDay,
+            date: idxToDate(classicDay).toISOString().slice(0, 10),
+        });
+    }
+
+    // Other modes: O(1) lookup via per-mode reverse indices
+    for (const mode of Object.keys(MODE_SLOT_OFFSETS)) {
+        if (mode === 'classic') continue;
+        const idx = ensureModeReverseIndex(langCode, mode);
+        const entry = idx.map.get(w);
+        if (entry) {
+            const boardCount = MODE_BOARD_COUNTS[mode] ?? 1;
+            appearances.push({
+                mode,
+                dayIdx: entry.modeDayIdx,
+                date: idxToDate(entry.classicDayIdx).toISOString().slice(0, 10),
+                ...(boardCount > 1 ? { board: entry.board } : {}),
+            });
+        }
+    }
+
+    appearances.sort((a, b) => b.dayIdx - a.dayIdx);
+    return appearances;
 }
 
 // ---------------------------------------------------------------------------

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -137,6 +137,8 @@ export interface LanguageText {
     hard_mode_position?: string;
     hard_mode_contains?: string;
     win_words?: string;
+    share_challenge_lose?: string;
+    share_challenge_win?: string;
 }
 
 export interface LanguageHelp {
@@ -159,6 +161,20 @@ export interface LanguageHelp {
     speed_scoring_explanation?: string;
     speed_pressure?: string;
     speed_pressure_explanation?: string;
+    // Semantic mode
+    semantic_subtitle?: string;
+    semantic_rank_title?: string;
+    semantic_rank_explanation?: string;
+    semantic_rank_found?: string;
+    semantic_compass_title?: string;
+    semantic_compass_explanation?: string;
+    semantic_compass_latest_guess?: string;
+    semantic_compass_toward?: string;
+    semantic_map_title?: string;
+    semantic_map_explanation?: string;
+    semantic_oracle_title?: string;
+    semantic_oracle_explanation?: string;
+    semantic_footer?: string;
 }
 
 export interface UiStrings {
@@ -342,6 +358,8 @@ export interface UiStrings {
     mode_multiboard_label?: string;
     mode_custom_label?: string;
     mode_custom_desc?: string;
+    mode_classic_label?: string;
+    mode_classic_desc?: string;
     mode_party_label?: string;
     mode_party_desc?: string;
     // Semantic Explorer
@@ -396,6 +414,9 @@ export interface UiStrings {
     semantic_unavailable?: string;
     semantic_retry?: string;
     semantic_unlimited?: string;
+    // Sidebar
+    sidebar_play?: string;
+    sidebar_you?: string;
 }
 
 export interface LanguageConfig {

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pg8000"
+version = "1.31.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "scramp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/9a/077ab21e700051e03d8c5232b6bcb9a1a4d4b6242c9a0226df2cfa306414/pg8000-1.31.5.tar.gz", hash = "sha256:46ebb03be52b7a77c03c725c79da2ca281d6e8f59577ca66b17c9009618cae78", size = 118933, upload-time = "2025-09-14T09:16:49.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/07/5fd183858dff4d24840f07fc845f213cd371a19958558607ba22035dadd7/pg8000-1.31.5-py3-none-any.whl", hash = "sha256:0af2c1926b153307639868d2ee5cef6cd3a7d07448e12736989b10e1d491e201", size = 57816, upload-time = "2025-09-14T09:16:47.798Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -563,6 +585,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.2.19"
 source = { registry = "https://pypi.org/simple" }
@@ -692,6 +726,18 @@ wheels = [
 ]
 
 [[package]]
+name = "scramp"
+version = "1.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/52/a866f1ac9ae9025ec7f9bea803bba9d54796f8a84236165a700831f61b27/scramp-1.4.8.tar.gz", hash = "sha256:bd018fabfe46343cceeb9f1c3e8d23f55770271e777e3accbfaee3ff0a316e71", size = 16630, upload-time = "2026-01-06T21:01:01.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/07/a962d2477331abfdb2c6a8251b65c673dbb07ad707d1882d61562b8b9147/scramp-1.4.8-py3-none-any.whl", hash = "sha256:87c2f15976845a2872fe5490a06097f0d01813cceb53774ea168c911f2ad025c", size = 13121, upload-time = "2026-01-06T21:00:59.474Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -775,6 +821,7 @@ dependencies = [
     { name = "arabic-reshaper" },
     { name = "grapheme" },
     { name = "openai" },
+    { name = "pg8000" },
     { name = "pillow" },
     { name = "python-bidi" },
 ]
@@ -791,6 +838,7 @@ requires-dist = [
     { name = "arabic-reshaper", specifier = ">=3.0.0" },
     { name = "grapheme", specifier = ">=0.6.0" },
     { name = "openai", specifier = ">=2.21.0" },
+    { name = "pg8000", specifier = ">=1.31.5" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "python-bidi", specifier = "==0.4.2" },
 ]


### PR DESCRIPTION
## Summary

- **Native comments** replacing Giscus on word pages — flat list, auth to post, real-time game result badges (single SQL query, no stored metadata)
- **Bug report modal** replacing GitHub Issues link — stores in DB, optional email via Resend
- **Word dictionary & translations** — full Wiktionary entries, cross-language links with SSR-safe names
- **Hydration fix** — WordTranslations was causing 80+ hydration mismatches (client-side langNames cache vs server codes), corrupting Vue's component tree and breaking teleports/sign-in modal
- **useHead dispose fix** — merged 3 separate useHead/useSeoMeta calls into 1 to avoid @unhead/vue crash on unmount
- **Type safety** — 45 → 0 TypeScript errors across 25+ files
- **Passkey auth** — LoginModal rewrite with multi-step flow
- **Prisma schema** — Comment model, TargetNeighbor model (was orphaned 4.4M-row table)

## SEO audit

All word page SEO elements verified in SSR output:
- `<title>`, description, OG tags, Twitter cards, canonical, robots — identical to before
- JSON-LD enriched with pronunciation + etymology from kaikki data
- Translations now SSR-rendered correctly (were hydration-mismatched before)
- Comments server-rendered (Giscus was client-only iframe)

## Security audit

- SQL injection: all user inputs parameterized, appearances capped at 20
- XSS: Vue `{{ }}` auto-escapes, no v-html
- Rate limiting: 5 comments/10min per IP, 3 reports/hour per IP
- Moderation: profanity regex, URL blocking, repeated char detection
- Input validation: comment 500 chars, report 2000 chars, cursor date validated

## Test plan

- [x] `vue-tsc --noEmit` — 0 errors
- [x] `pnpm test` — 590 passed (1 flaky DB timeout, pre-existing)
- [x] SSR output verified: title, meta, JSON-LD, canonical all present
- [x] Comments render with badges on `/en/word/light` (seeded test data)
- [x] Hydration mismatch eliminated (verified via Chrome console)
- [x] Sign-in modal works on word pages (was broken by hydration corruption)
- [ ] Test comment posting when logged in
- [ ] Test report modal from sidebar
- [ ] Dark mode + RTL layout verification
- [ ] Mobile responsive check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-app report/feedback submission functionality
  * Added community discussion section on word pages
  * Added dictionary definitions with etymology and pronunciation
  * Added word translations across languages
  * Added word images with clickable expansion
  * Added word appearance history across game modes
  * Enhanced login flow with improved passkey support and platform preferences

* **Improvements**
  * Added informational tooltips for semantic explorer features
  * Improved definition retrieval from database sources

* **Bug Fixes**
  * Fixed word image API caching behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->