### PR TITLE
Prepare the project for selfhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-# Stage 1: Build frontend assets
-FROM node:22-slim AS builder
-RUN corepack enable
-WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
-COPY . .
-RUN pnpm build
-
-# Stage 2: Production image
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY --from=builder /app/webapp ./webapp
-COPY data ./data
+COPY . .
 CMD ["gunicorn", "--chdir", "webapp", "-b", "0.0.0.0:8000", "app:app"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,9 @@ from flask import (
     url_for,
     request,
 )
+
+from werkzeug.middleware.proxy_fix import ProxyFix
+
 import json
 
 import datetime
@@ -16,6 +19,8 @@ import random
 random.seed(42)
 
 app = Flask(__name__)
+
+app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 
 ###############################################################################
 # DATA


### PR DESCRIPTION
- [x] The project doesn't include any package.json nor pnpm-lock.yaml. It just serves static files. So the initial Dockerfile is not valid
- [x] The flask configuration doesn't work behind reverse proxy; which is the usual config on most cases.
- [ ] The instance URL is hardcoded in python and js files, We need to have a json config file to handle them instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker build process by consolidating the multi-stage build into a single optimized runtime image, improving build efficiency and reducing complexity
  * Added support for reverse proxy deployments to ensure proper request headers and routing in proxied environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hugo0/wordle/pull/202)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->